### PR TITLE
Scaffold bilingual Electron UI foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.DS_Store
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -9,3 +9,20 @@ This repository captures the product and technical specification for the Local B
 - AI-assisted conversations grounded in the contents of each collection.
 
 See [`docs/functional_spec.md`](docs/functional_spec.md) for the detailed functional specification.
+
+## Development Setup / 开发环境准备
+
+1. Install dependencies 安装依赖：
+   ```bash
+   npm install
+   ```
+2. Start the bilingual Electron + React workspace 启动中英文双语界面：
+   ```bash
+   npm run dev
+   ```
+   The command launches the Vite renderer dev server and boots Electron with hot-reloading TypeScript support.
+
+3. Build production assets 构建生产资源：
+   ```bash
+   npm run build
+   ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "local-bookshelf",
+  "version": "0.1.0",
+  "description": "Local Bookshelf desktop application",
+  "main": "dist/main/main.js",
+  "author": "",
+  "license": "MIT",
+  "scripts": {
+    "dev": "concurrently \"npm:dev:renderer\" \"npm:dev:main\"",
+    "dev:renderer": "vite",
+    "dev:main": "cross-env NODE_ENV=development VITE_DEV_SERVER_URL=http://localhost:5173 electron -r ts-node/register ./src/main/main.ts",
+    "build": "npm run build:renderer && npm run build:main && npm run build:preload",
+    "build:renderer": "vite build",
+    "build:main": "tsc -p tsconfig.main.json",
+    "build:preload": "tsc -p tsconfig.preload.json"
+  },
+  "dependencies": {
+    "electron": "^28.2.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.17",
+    "@types/react": "^18.2.47",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.12"
+  }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,0 +1,53 @@
+import { app, BrowserWindow, nativeTheme } from 'electron';
+import path from 'path';
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+if (isDev) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('ts-node').register({
+    project: path.resolve(__dirname, '../../tsconfig.preload.json')
+  });
+}
+
+function createMainWindow() {
+  const mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    minWidth: 1024,
+    minHeight: 640,
+    backgroundColor: nativeTheme.shouldUseDarkColors ? '#1e1e1e' : '#ffffff',
+    webPreferences: {
+      preload: isDev
+        ? path.join(__dirname, '../preload/index.ts')
+        : path.join(__dirname, '..', 'preload', 'index.js'),
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  });
+
+  if (isDev) {
+    const rendererUrl = process.env.VITE_DEV_SERVER_URL ?? 'http://localhost:5173';
+    mainWindow.loadURL(rendererUrl);
+    mainWindow.webContents.openDevTools({ mode: 'detach' });
+  } else {
+    const rendererPath = path.join(__dirname, '..', 'renderer', 'index.html');
+    mainWindow.loadFile(rendererPath);
+  }
+}
+
+app.whenReady().then(() => {
+  createMainWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createMainWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,0 +1,5 @@
+import { contextBridge } from 'electron';
+
+contextBridge.exposeInMainWorld('localBookshelf', {
+  version: '0.1.0'
+});

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,0 +1,220 @@
+import { useMemo, useState } from 'react';
+
+interface DashboardStat {
+  id: string;
+  label: string;
+  value: string;
+  helper: string;
+}
+
+interface CollectionPreview {
+  id: string;
+  title: string;
+  description: string;
+  stats: string;
+  actions: string[];
+}
+
+interface TranslationPack {
+  localeLabel: string;
+  heroTitle: string;
+  heroSubtitle: string;
+  stats: DashboardStat[];
+  collectionsTitle: string;
+  collectionsSubtitle: string;
+  collections: CollectionPreview[];
+  newCollectionLabel: string;
+  roadmapTitle: string;
+  roadmapItems: string[];
+}
+
+const translations: Record<'en' | 'zh', TranslationPack> = {
+  en: {
+    localeLabel: 'Language',
+    heroTitle: 'Local Bookshelf Experience Blueprint',
+    heroSubtitle:
+      'A bilingual reference UI that maps the Functional Specification into a tangible Electron + React layout skeleton.',
+    stats: [
+      { id: 'collections', label: 'Collections', value: '6', helper: 'Tracked across themed libraries' },
+      { id: 'books', label: 'Books Indexed', value: '2,438', helper: 'All supported formats combined' },
+      { id: 'enrichment', label: 'Metadata Enrichment', value: '87%', helper: 'Completed enrichment coverage' },
+      { id: 'reading', label: 'Active Readers', value: '3', helper: 'Continue reading where you left off' }
+    ],
+    collectionsTitle: 'Collections',
+    collectionsSubtitle: 'Hover actions lead to editing, reading, and AI conversations for each curated shelf.',
+    collections: [
+      {
+        id: 'new-collection',
+        title: 'New Collection',
+        description: 'Launch the creation wizard to add folders, metadata, and a custom cover.',
+        stats: 'Wizard · Drag & Drop Paths · Auto Scan',
+        actions: ['Start Wizard']
+      },
+      {
+        id: 'climate',
+        title: 'Climate Futures Research',
+        description: 'Deep dive into scientific reports, policy briefs, and open data handbooks.',
+        stats: '412 books · Last opened 2 days ago',
+        actions: ['Resume Reading', 'Open AI Chat', 'Edit']
+      },
+      {
+        id: 'design',
+        title: 'Design Systems',
+        description: 'Pattern libraries, accessibility guidelines, and design tokens references.',
+        stats: '198 books · Metadata 95% complete',
+        actions: ['Preview Library', 'Export PDF Set', 'Edit']
+      },
+      {
+        id: 'literature',
+        title: 'Modern Chinese Literature',
+        description: 'Digitised novels, essays, and poetry with bilingual commentary notes.',
+        stats: '867 books · AI summaries enabled',
+        actions: ['Continue Listening', 'Open AI Chat', 'Edit']
+      }
+    ],
+    newCollectionLabel: 'Start Wizard',
+    roadmapTitle: 'Key Experience Pillars',
+    roadmapItems: [
+      'Dashboard analytics combine collection health, format distribution, and last activity at a glance.',
+      'Collection detail pages support card and table layouts with full-text search, filters, and pagination presets.',
+      'Reader pipeline covers PDF, EPUB, MOBI, DOCX, TXT, and more with persistent bookmarks and TTS controls.',
+      'AI assistant grounds every response in local embeddings, returning citations per answer turn.'
+    ]
+  },
+  zh: {
+    localeLabel: '语言',
+    heroTitle: '本地书架体验蓝图',
+    heroSubtitle: '基于功能规格的双语界面雏形，展示 Electron + React 架构的核心布局。',
+    stats: [
+      { id: 'collections', label: '收藏集', value: '6', helper: '按主题管理的数字书库' },
+      { id: 'books', label: '已索引图书', value: '2,438', helper: '涵盖全部支持的格式' },
+      { id: 'enrichment', label: '元数据完善率', value: '87%', helper: '自动补全的覆盖情况' },
+      { id: 'reading', label: '活跃阅读者', value: '3', helper: '从上次进度无缝续读' }
+    ],
+    collectionsTitle: '收藏集',
+    collectionsSubtitle: '悬停操作包括编辑、阅读与 AI 对话，快速进入任意策展书架。',
+    collections: [
+      {
+        id: 'new-collection',
+        title: '创建新收藏集',
+        description: '打开多步骤向导，添加文件夹、元数据与封面。',
+        stats: '向导 · 拖放路径 · 自动扫描',
+        actions: ['启动向导']
+      },
+      {
+        id: 'climate',
+        title: '气候未来研究',
+        description: '深入科学报告、政策文件与开放数据手册。',
+        stats: '412 本 · 2 天前访问',
+        actions: ['继续阅读', '开启 AI 对话', '编辑']
+      },
+      {
+        id: 'design',
+        title: '设计系统文库',
+        description: '包含模式库、无障碍指南与设计令牌参考。',
+        stats: '198 本 · 元数据完善率 95%',
+        actions: ['预览文库', '批量导出 PDF', '编辑']
+      },
+      {
+        id: 'literature',
+        title: '现代中文文学',
+        description: '小说、散文与诗歌，附中英双语注释。',
+        stats: '867 本 · 已启用 AI 摘要',
+        actions: ['继续听书', '开启 AI 对话', '编辑']
+      }
+    ],
+    newCollectionLabel: '启动向导',
+    roadmapTitle: '关键体验支柱',
+    roadmapItems: [
+      '仪表盘总览收藏健康、格式分布与最近活动，一屏掌握核心数据。',
+      '收藏详情页提供卡片与表格双视图，支持全文搜索、分类过滤与分页记忆。',
+      '阅读器覆盖 PDF、EPUB、MOBI、DOCX、TXT 等格式，并保存书签及朗读控制。',
+      'AI 助手基于本地向量索引返回答案，并在每轮对话中附带引用。'
+    ]
+  }
+};
+
+export default function App() {
+  const [locale, setLocale] = useState<'en' | 'zh'>('en');
+  const pack = translations[locale];
+
+  const renderCollections = useMemo(() => {
+    return pack.collections.map((collection) => {
+      const isNew = collection.id === 'new-collection';
+      return (
+        <div
+          key={collection.id}
+          className={`collection-card ${isNew ? 'new-collection-card' : ''}`}
+        >
+          <h4>{collection.title}</h4>
+          <p>{collection.description}</p>
+          <p>{collection.stats}</p>
+          <div className="collection-actions">
+            {collection.actions.map((action) => (
+              <button key={action}>{action}</button>
+            ))}
+          </div>
+        </div>
+      );
+    });
+  }, [pack.collections]);
+
+  return (
+    <div className="app-shell">
+      <header className="top-bar">
+        <div>
+          <h1>{pack.heroTitle}</h1>
+          <p>{pack.heroSubtitle}</p>
+        </div>
+        <div className="language-toggle" role="group" aria-label={pack.localeLabel}>
+          <span>{pack.localeLabel}</span>
+          <button
+            type="button"
+            className={locale === 'en' ? 'active' : ''}
+            onClick={() => setLocale('en')}
+          >
+            English
+          </button>
+          <button
+            type="button"
+            className={locale === 'zh' ? 'active' : ''}
+            onClick={() => setLocale('zh')}
+          >
+            中文
+          </button>
+        </div>
+      </header>
+
+      <section className="dashboard-grid" aria-label="dashboard">
+        {pack.stats.map((stat) => (
+          <article className="dashboard-card" key={stat.id}>
+            <h3>{stat.label}</h3>
+            <strong>{stat.value}</strong>
+            <p>{stat.helper}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="collection-section">
+        <div className="section-header">
+          <h2>{pack.collectionsTitle}</h2>
+          <p>{pack.collectionsSubtitle}</p>
+        </div>
+        <div className="collection-grid">{renderCollections}</div>
+      </section>
+
+      <section className="collection-section">
+        <div className="section-header">
+          <h2>{pack.roadmapTitle}</h2>
+        </div>
+        <div className="dashboard-grid multi-column">
+          {pack.roadmapItems.map((item, index) => (
+            <article key={index} className="dashboard-card">
+              <p>{item}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Local Bookshelf</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -1,0 +1,173 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 45%, #0f172a 100%);
+  padding: 24px;
+  gap: 24px;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.language-toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background-color: rgba(15, 23, 42, 0.6);
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.language-toggle button {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: #e2e8f0;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.language-toggle button.active {
+  background: linear-gradient(135deg, #38bdf8 0%, #6366f1 100%);
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.dashboard-card {
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 16px;
+  padding: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.45);
+}
+
+.dashboard-card h3 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-size: 1rem;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.dashboard-card strong {
+  font-size: 2rem;
+  color: #f8fafc;
+}
+
+.collection-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.collection-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.collection-card {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 20px;
+  padding: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.collection-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(96, 165, 250, 0.6);
+}
+
+.collection-card h4 {
+  margin: 0;
+  color: #f8fafc;
+  font-size: 1.1rem;
+}
+
+.collection-card p {
+  margin: 0;
+  color: #cbd5f5;
+  font-size: 0.9rem;
+}
+
+.collection-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.collection-actions button {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.8);
+  color: #e2e8f0;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.collection-actions button:hover {
+  background: linear-gradient(135deg, #38bdf8 0%, #6366f1 100%);
+  color: #0f172a;
+  border-color: transparent;
+}
+
+.new-collection-card {
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: #94a3b8;
+  font-weight: 500;
+}
+
+.multi-column {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 900px) {
+  .multi-column {
+    grid-template-columns: 1fr;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "baseUrl": "."
+  },
+  "exclude": ["dist", "node_modules"]
+}

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/main",
+    "module": "CommonJS",
+    "types": ["node"],
+    "lib": ["ES2020"]
+  },
+  "include": ["src/main/**/*.ts"]
+}

--- a/tsconfig.preload.json
+++ b/tsconfig.preload.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/preload",
+    "module": "CommonJS",
+    "types": ["node"],
+    "lib": ["ES2020"]
+  },
+  "include": ["src/preload/**/*.ts"]
+}

--- a/tsconfig.renderer.json
+++ b/tsconfig.renderer.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src/renderer/**/*"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  root: path.resolve(__dirname, 'src/renderer'),
+  plugins: [react()],
+  base: './',
+  build: {
+    outDir: path.resolve(__dirname, 'dist/renderer'),
+    emptyOutDir: true
+  },
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add Electron + React tooling with TypeScript configurations for main, preload, and renderer processes
- introduce bilingual (English/Chinese) renderer layout illustrating dashboard, collection, and roadmap sections
- document development workflow and environment setup steps in both languages

## Testing
- npm install *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b577a8388320bb1e9adaa15cdeaa