### PR TITLE
Add interactive Local Bookshelf workflows

### DIFF
--- a/src/renderer/data.js
+++ b/src/renderer/data.js
@@ -4,6 +4,10 @@ export const translations = {
     heroTitle: 'Local Bookshelf Experience Blueprint',
     heroSubtitle:
       'A bilingual reference UI that maps the Functional Specification into a tangible Electron + React layout skeleton.',
+    actionBar: {
+      openSettings: 'Settings',
+      toggleMonitor: 'Background Jobs'
+    },
     stats: [
       { id: 'collections', label: 'Collections', value: '6', helper: 'Tracked across themed libraries' },
       { id: 'books', label: 'Books Indexed', value: '2,438', helper: 'All supported formats combined' },
@@ -49,12 +53,160 @@ export const translations = {
       'Collection detail pages support card and table layouts with full-text search, filters, and pagination presets.',
       'Reader pipeline covers PDF, EPUB, MOBI, DOCX, TXT, and more with persistent bookmarks and TTS controls.',
       'AI assistant grounds every response in local embeddings, returning citations per answer turn.'
-    ]
+    ],
+    wizard: {
+      title: 'New Collection Wizard',
+      steps: [
+        { title: 'Choose Folders', helper: 'Drag and drop or pick directories that should be scanned.' },
+        { title: 'Describe Collection', helper: 'Add a name and optional description for quick discovery.' },
+        { title: 'Select Cover', helper: 'Upload a PNG, JPG, or WebP image that represents the shelf.' }
+      ],
+      directoryPlaceholder: 'Add directories…',
+      addPathButton: 'Add Path',
+      emptyPathHelper: 'No folders selected yet. Start with a handbook archive, downloads folder, or NAS share.',
+      nameLabel: 'Collection Name',
+      descriptionLabel: 'Description',
+      coverLabel: 'Cover Image',
+      browseLabel: 'Browse…',
+      dropHint: 'Drop image here or use the file picker.',
+      next: 'Next',
+      back: 'Back',
+      cancel: 'Cancel',
+      finish: 'Create Collection',
+      validations: {
+        missingName: 'Please provide a collection name.',
+        duplicateName: 'A collection with the same name already exists.',
+        missingPaths: 'Select at least one accessible directory.',
+        invalidCover: 'Only PNG, JPG, and WebP formats are supported.'
+      },
+      successTitle: 'Scan Started',
+      successBody:
+        'We are scanning your folders in the background. Progress appears in the job monitor and collection dashboard.'
+    },
+    monitor: {
+      title: 'Background Jobs',
+      tableHeaders: ['Job', 'Collection', 'Progress', 'Status', 'Updated'],
+      empty: 'No active jobs. Launch a rescan or metadata refresh to see updates.',
+      statuses: {
+        queued: 'Queued',
+        running: 'Scanning',
+        completed: 'Completed',
+        failed: 'Failed'
+      }
+    },
+    collectionDetail: {
+      titlePrefix: 'Collection',
+      subtitle: 'Search, filter, and manage every title inside this shelf.',
+      searchPlaceholder: 'Search title, author, notes…',
+      filters: {
+        classification: 'Classification',
+        format: 'Format',
+        publication: 'Publication Year',
+        from: 'From',
+        to: 'To',
+        apply: 'Apply Filters',
+        reset: 'Reset'
+      },
+      layoutToggle: {
+        cards: 'Card view',
+        table: 'Table view'
+      },
+      pagination: {
+        label: 'Items per page',
+        previous: 'Previous',
+        next: 'Next'
+      },
+      bulkActions: {
+        title: 'Bulk actions',
+        refreshMetadata: 'Refresh metadata',
+        export: 'Export to PDF',
+        selectAll: 'Select all',
+        clear: 'Clear selection'
+      },
+      cardActions: {
+        preview: 'Preview',
+        export: 'Export',
+        chat: 'AI Chat'
+      },
+      tableHeaders: ['Title', 'Author', 'Classification', 'Year', 'Format', 'Size', 'Date Added', 'Enrichment'],
+      noResults: 'No books match your current filters.',
+      resumeReading: 'Resume last session',
+      rescan: 'Rescan folders',
+      refresh: 'Refresh metadata',
+      openChat: 'Open AI chat'
+    },
+    previewPanel: {
+      title: 'Reader Preview',
+      currentPage: 'Page',
+      of: 'of',
+      zoomIn: 'Zoom in',
+      zoomOut: 'Zoom out',
+      fitWidth: 'Fit width',
+      fitPage: 'Fit page',
+      toggleFullscreen: 'Toggle fullscreen',
+      previousPage: 'Previous page',
+      nextPage: 'Next page',
+      addBookmark: 'Add bookmark',
+      removeBookmark: 'Remove bookmark',
+      savedBookmark: 'Bookmark saved',
+      removedBookmark: 'Bookmark removed'
+    },
+    ttsPanel: {
+      title: 'Text-to-Speech',
+      play: 'Play',
+      pause: 'Pause',
+      resume: 'Resume',
+      stop: 'Stop',
+      voice: 'Voice',
+      speed: 'Speed',
+      highlight: 'Highlight narration',
+      male: 'Male',
+      female: 'Female',
+      neutral: 'Neutral'
+    },
+    exportPanel: {
+      title: 'Export to PDF',
+      destination: 'Destination folder',
+      metadataPage: 'Include metadata cover page',
+      start: 'Start export',
+      progressLabel: 'Conversion progress',
+      success: 'Export completed',
+      failure: 'Export failed. Please try again.'
+    },
+    aiPanel: {
+      title: 'AI Research Assistant',
+      placeholder: 'Ask about themes, chapters, or request summaries…',
+      send: 'Send',
+      citationLabel: 'Source',
+      newChat: 'New session',
+      groundingNotice: 'Responses are grounded in locally indexed embeddings.'
+    },
+    settings: {
+      title: 'Preferences',
+      tabs: ['Metadata', 'Storage', 'Reader'],
+      metadataSources: 'Metadata sources',
+      apiKey: 'API key',
+      rateLimit: 'Rate limit (req/min)',
+      proxy: 'Proxy URL',
+      cachePath: 'Cache directory',
+      previewPath: 'Preview artifacts',
+      embeddingsPath: 'Embeddings database',
+      paginationDefault: 'Default pagination',
+      theme: 'Theme',
+      analytics: 'Usage analytics',
+      offline: 'Offline mode',
+      save: 'Save preferences',
+      saved: 'Preferences saved'
+    }
   },
   zh: {
     localeLabel: '语言',
     heroTitle: '本地书架体验蓝图',
     heroSubtitle: '基于功能规格的双语界面雏形，展示 Electron + React 架构的核心布局。',
+    actionBar: {
+      openSettings: '系统设置',
+      toggleMonitor: '后台任务'
+    },
     stats: [
       { id: 'collections', label: '收藏集', value: '6', helper: '按主题管理的数字书库' },
       { id: 'books', label: '已索引图书', value: '2,438', helper: '涵盖全部支持的格式' },
@@ -100,6 +252,149 @@ export const translations = {
       '收藏详情页提供卡片与表格双视图，支持全文搜索、分类过滤与分页记忆。',
       '阅读器覆盖 PDF、EPUB、MOBI、DOCX、TXT 等格式，并保存书签及朗读控制。',
       'AI 助手基于本地向量索引返回答案，并在每轮对话中附带引用。'
-    ]
+    ],
+    wizard: {
+      title: '新建收藏集向导',
+      steps: [
+        { title: '选择文件夹', helper: '拖放或选择需要扫描的目录。' },
+        { title: '填写信息', helper: '添加名称与可选描述，便于快速识别。' },
+        { title: '设置封面', helper: '上传 PNG、JPG 或 WebP 图片作为封面。' }
+      ],
+      directoryPlaceholder: '添加目录…',
+      addPathButton: '新增路径',
+      emptyPathHelper: '尚未选择文件夹，可以从手册档案、下载目录或 NAS 开始。',
+      nameLabel: '收藏集名称',
+      descriptionLabel: '简介',
+      coverLabel: '封面图片',
+      browseLabel: '浏览…',
+      dropHint: '拖拽图片至此或使用文件选择器。',
+      next: '下一步',
+      back: '上一步',
+      cancel: '取消',
+      finish: '创建收藏集',
+      validations: {
+        missingName: '请填写收藏集名称。',
+        duplicateName: '已存在同名收藏集。',
+        missingPaths: '至少选择一个可访问的目录。',
+        invalidCover: '仅支持 PNG、JPG、WebP 格式。'
+      },
+      successTitle: '扫描已启动',
+      successBody: '我们正在后台扫描您的文件夹，进度会显示在任务监视器与收藏集面板。'
+    },
+    monitor: {
+      title: '后台任务',
+      tableHeaders: ['任务', '收藏集', '进度', '状态', '更新时间'],
+      empty: '暂无任务，可发起重新扫描或元数据刷新以查看动态。',
+      statuses: {
+        queued: '排队中',
+        running: '扫描中',
+        completed: '已完成',
+        failed: '失败'
+      }
+    },
+    collectionDetail: {
+      titlePrefix: '收藏集',
+      subtitle: '在此检索、过滤并管理书架中的每一本书。',
+      searchPlaceholder: '搜索标题、作者或笔记…',
+      filters: {
+        classification: '分类',
+        format: '格式',
+        publication: '出版年份',
+        from: '起始',
+        to: '结束',
+        apply: '应用筛选',
+        reset: '重置'
+      },
+      layoutToggle: {
+        cards: '卡片视图',
+        table: '表格视图'
+      },
+      pagination: {
+        label: '每页数量',
+        previous: '上一页',
+        next: '下一页'
+      },
+      bulkActions: {
+        title: '批量操作',
+        refreshMetadata: '刷新元数据',
+        export: '批量导出 PDF',
+        selectAll: '全选',
+        clear: '清除'
+      },
+      cardActions: {
+        preview: '预览',
+        export: '导出',
+        chat: 'AI 对话'
+      },
+      tableHeaders: ['标题', '作者', '分类', '年份', '格式', '大小', '添加时间', '完善状态'],
+      noResults: '没有符合当前筛选条件的图书。',
+      resumeReading: '继续上次阅读',
+      rescan: '重新扫描目录',
+      refresh: '刷新元数据',
+      openChat: '打开 AI 对话'
+    },
+    previewPanel: {
+      title: '阅读器预览',
+      currentPage: '第',
+      of: '页，共',
+      zoomIn: '放大',
+      zoomOut: '缩小',
+      fitWidth: '适应宽度',
+      fitPage: '适应页面',
+      toggleFullscreen: '全屏切换',
+      previousPage: '上一页',
+      nextPage: '下一页',
+      addBookmark: '添加书签',
+      removeBookmark: '移除书签',
+      savedBookmark: '书签已保存',
+      removedBookmark: '书签已移除'
+    },
+    ttsPanel: {
+      title: '文本转语音',
+      play: '播放',
+      pause: '暂停',
+      resume: '继续',
+      stop: '停止',
+      voice: '声音',
+      speed: '语速',
+      highlight: '高亮朗读文本',
+      male: '男声',
+      female: '女声',
+      neutral: '中性'
+    },
+    exportPanel: {
+      title: '导出为 PDF',
+      destination: '导出目录',
+      metadataPage: '附加元数据封面页',
+      start: '开始导出',
+      progressLabel: '转换进度',
+      success: '导出完成',
+      failure: '导出失败，请重试。'
+    },
+    aiPanel: {
+      title: 'AI 研究助手',
+      placeholder: '询问主题、章节或请求摘要…',
+      send: '发送',
+      citationLabel: '引用来源',
+      newChat: '新会话',
+      groundingNotice: '回答基于本地嵌入索引并附带引用。'
+    },
+    settings: {
+      title: '偏好设置',
+      tabs: ['元数据', '存储', '阅读器'],
+      metadataSources: '元数据来源',
+      apiKey: 'API 密钥',
+      rateLimit: '速率限制（次/分钟）',
+      proxy: '代理地址',
+      cachePath: '封面缓存路径',
+      previewPath: '预览文件存储',
+      embeddingsPath: '向量数据库',
+      paginationDefault: '默认分页数量',
+      theme: '主题',
+      analytics: '使用分析',
+      offline: '离线模式',
+      save: '保存设置',
+      saved: '设置已保存'
+    }
   }
 };

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -1,7 +1,420 @@
 import { translations } from './data.js';
 
 const root = document.getElementById('root');
-let currentLocale = 'en';
+
+const supportedCoverTypes = ['image/png', 'image/jpeg', 'image/webp'];
+
+const classificationCatalog = {
+  'climate.adaptation': { en: 'Climate Adaptation', zh: '气候适应' },
+  'climate.policy': { en: 'Climate Policy', zh: '气候政策' },
+  'climate.science': { en: 'Earth System Science', zh: '地球系统科学' },
+  'climate.energy': { en: 'Energy Transition', zh: '能源转型' },
+  'design.systems': { en: 'Design Systems', zh: '设计系统' },
+  'design.process': { en: 'Product Process', zh: '产品流程' },
+  'design.accessibility': { en: 'Accessibility', zh: '无障碍' },
+  'literature.fiction': { en: 'Modern Fiction', zh: '现代小说' },
+  'literature.poetry': { en: 'Poetry', zh: '诗歌' },
+  'literature.essay': { en: 'Essay & Critique', zh: '随笔与评论' }
+};
+
+const formatCatalog = {
+  pdf: { en: 'PDF', zh: 'PDF' },
+  epub: { en: 'EPUB', zh: 'EPUB' },
+  mobi: { en: 'MOBI', zh: 'MOBI' },
+  docx: { en: 'DOCX', zh: 'DOCX' },
+  txt: { en: 'Plain Text', zh: '纯文本' },
+  azw3: { en: 'AZW3', zh: 'AZW3' }
+};
+
+const enrichmentLabels = {
+  complete: { en: 'Complete', zh: '已完成' },
+  inprogress: { en: 'In Progress', zh: '进行中' },
+  queued: { en: 'Queued', zh: '排队中' },
+  failed: { en: 'Failed', zh: '失败' }
+};
+
+const classificationOptions = [
+  'climate.adaptation',
+  'climate.policy',
+  'climate.science',
+  'climate.energy',
+  'design.systems',
+  'design.process',
+  'design.accessibility',
+  'literature.fiction',
+  'literature.poetry',
+  'literature.essay'
+];
+
+const formatOptions = ['pdf', 'epub', 'mobi', 'docx', 'txt', 'azw3'];
+
+const directoryOptions = [
+  {
+    id: 'handbooks',
+    path: '/Volumes/Research/Climate-Handbooks',
+    helper: 'Shared folder mounted from NAS',
+    lastIndexed: '2024-05-22T08:30:00Z'
+  },
+  {
+    id: 'ipcc',
+    path: '/Users/alex/Documents/IPCC-AR6',
+    helper: 'Downloaded assessment reports',
+    lastIndexed: '2024-05-20T10:02:00Z'
+  },
+  {
+    id: 'design-system',
+    path: 'D:/Libraries/Design-Systems',
+    helper: 'Sketches, PDFs, and pattern audits',
+    lastIndexed: '2024-04-28T14:10:00Z'
+  },
+  {
+    id: 'literature',
+    path: '/Volumes/Archive/Modern-Literature',
+    helper: 'Digitised literary anthologies',
+    lastIndexed: '2024-05-12T21:40:00Z'
+  }
+];
+
+const initialCollectionMetadata = {
+  climate: {
+    directories: ['/Volumes/Research/Climate-Handbooks', '/Users/alex/Documents/IPCC-AR6'],
+    lastScan: '2024-06-02T10:30:00Z',
+    pagination: 20,
+    aiEnabled: true
+  },
+  design: {
+    directories: ['D:/Libraries/Design-Systems', 'D:/Libraries/Accessibility-Guides'],
+    lastScan: '2024-05-28T18:20:00Z',
+    pagination: 12,
+    aiEnabled: true
+  },
+  literature: {
+    directories: ['/Volumes/Archive/Modern-Literature'],
+    lastScan: '2024-06-04T09:05:00Z',
+    pagination: 50,
+    aiEnabled: true
+  }
+};
+
+const initialCollectionBooks = {
+  climate: [
+    {
+      id: 'climate-1',
+      title: 'Resilient Cities 2040',
+      author: 'Mara Liang',
+      classification: 'climate.adaptation',
+      publicationYear: 2024,
+      format: 'pdf',
+      sizeMB: 18.4,
+      dateAdded: '2024-05-18',
+      enrichment: 'complete',
+      pages: 328,
+      progress: { currentPage: 215 },
+      isbn: '978-0-12-864302-1',
+      summary: 'Action playbook for municipal adaptation projects across coastal regions.',
+      preview:
+        'Chapter 7 synthesises community-led design sprints with parametric flood models, outlining a replicable strategy for mid-sized cities.',
+      bookmarks: [64, 214],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'climate-2',
+      title: 'Policy Pathways for Net-Zero Provinces',
+      author: 'Dr. Felix Noor',
+      classification: 'climate.policy',
+      publicationYear: 2022,
+      format: 'epub',
+      sizeMB: 6.2,
+      dateAdded: '2024-04-11',
+      enrichment: 'inprogress',
+      pages: 412,
+      progress: { currentPage: 87 },
+      isbn: '978-1-4028-9462-9',
+      summary: 'Comparative policy toolkit aligning provincial statutes with national carbon commitments.',
+      preview:
+        'Section 3.2 analyses differentiated responsibilities across heavy industry clusters with annotated case law.',
+      bookmarks: [23, 198],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'climate-3',
+      title: 'Ocean Heat Budget Explorer',
+      author: 'IPCC Working Group I',
+      classification: 'climate.science',
+      publicationYear: 2023,
+      format: 'pdf',
+      sizeMB: 52.7,
+      dateAdded: '2024-03-07',
+      enrichment: 'complete',
+      pages: 512,
+      progress: { currentPage: 132 },
+      isbn: '978-0-321-87777-4',
+      summary: 'High-resolution datasets and visualisations for ocean heat content analysis.',
+      preview:
+        'Appendix D introduces a methodology for downscaling CMIP6 outputs with GPU-accelerated interpolation.',
+      bookmarks: [112, 256, 401],
+      tts: false,
+      exportable: true
+    },
+    {
+      id: 'climate-4',
+      title: 'Distributed Energy Retrofit Manual',
+      author: 'Helena Ortiz',
+      classification: 'climate.energy',
+      publicationYear: 2021,
+      format: 'docx',
+      sizeMB: 9.1,
+      dateAdded: '2024-02-19',
+      enrichment: 'queued',
+      pages: 226,
+      progress: { currentPage: 34 },
+      isbn: '978-0-452-29078-6',
+      summary: 'Practical guidance for retrofitting mid-rise buildings with hybrid solar microgrids.',
+      preview:
+        'Workbook templates cover financial modelling, procurement sequencing, and occupant engagement scripts.',
+      bookmarks: [48],
+      tts: true,
+      exportable: true
+    }
+  ],
+  design: [
+    {
+      id: 'design-1',
+      title: 'Multi-Platform Design Tokens',
+      author: 'Lina Osei',
+      classification: 'design.systems',
+      publicationYear: 2023,
+      format: 'pdf',
+      sizeMB: 12.2,
+      dateAdded: '2024-05-01',
+      enrichment: 'complete',
+      pages: 280,
+      progress: { currentPage: 144 },
+      isbn: '978-0-07-352343-1',
+      summary: 'Unified token taxonomy bridging web, desktop, and native mobile design systems.',
+      preview:
+        'The alignment matrix maps each decision token to platform accessibility requirements with traceable histories.',
+      bookmarks: [56, 233],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'design-2',
+      title: 'Inclusive Motion Guidelines',
+      author: 'Yuko Nishimura',
+      classification: 'design.accessibility',
+      publicationYear: 2020,
+      format: 'pdf',
+      sizeMB: 4.8,
+      dateAdded: '2024-04-16',
+      enrichment: 'complete',
+      pages: 164,
+      progress: { currentPage: 98 },
+      isbn: '978-0-12-549080-2',
+      summary: 'Framework for designing motion systems that respect vestibular comfort and localisation.',
+      preview:
+        'Case studies demonstrate velocity envelopes and offer CSS/SwiftUI code recipes to ship responsibly.',
+      bookmarks: [34, 88, 129],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'design-3',
+      title: 'Operational Playbook for DesignOps',
+      author: 'Carlos Mendes',
+      classification: 'design.process',
+      publicationYear: 2021,
+      format: 'epub',
+      sizeMB: 5.6,
+      dateAdded: '2024-03-08',
+      enrichment: 'inprogress',
+      pages: 312,
+      progress: { currentPage: 201 },
+      isbn: '978-0-7637-2026-6',
+      summary: 'Roadmap for scaling design systems governance with measurable service levels.',
+      preview:
+        'The service blueprint highlights intake triage, triads, and backlog analytics for distributed teams.',
+      bookmarks: [76, 240],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'design-4',
+      title: 'Accessibility Compliance Field Notes',
+      author: 'Priya Venkataraman',
+      classification: 'design.accessibility',
+      publicationYear: 2019,
+      format: 'docx',
+      sizeMB: 3.4,
+      dateAdded: '2024-02-14',
+      enrichment: 'complete',
+      pages: 198,
+      progress: { currentPage: 45 },
+      isbn: '978-0-13-466535-4',
+      summary: 'Annotated checklist mapping WCAG 2.2 success criteria to practical inspection routines.',
+      preview:
+        'Field observations catalogue recurring defects and remediation scripts used by enterprise auditors.',
+      bookmarks: [18, 172],
+      tts: true,
+      exportable: true
+    }
+  ],
+  literature: [
+    {
+      id: 'literature-1',
+      title: 'Midnight Courtyard',
+      author: 'Han Yuerong',
+      classification: 'literature.fiction',
+      publicationYear: 2018,
+      format: 'epub',
+      sizeMB: 2.3,
+      dateAdded: '2024-05-30',
+      enrichment: 'complete',
+      pages: 296,
+      progress: { currentPage: 186 },
+      isbn: '978-7-5321-6783-4',
+      summary: 'Interwoven narratives exploring urban solitude and resilience in Shanghai.',
+      preview:
+        'Chapter 12 juxtaposes architectural memories with present-day dialogues, inviting reflective annotation.',
+      bookmarks: [45, 132, 205],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'literature-2',
+      title: 'Letters to the South Wind',
+      author: 'Qiu Ansheng',
+      classification: 'literature.essay',
+      publicationYear: 2020,
+      format: 'pdf',
+      sizeMB: 7.9,
+      dateAdded: '2024-04-22',
+      enrichment: 'complete',
+      pages: 224,
+      progress: { currentPage: 44 },
+      isbn: '978-7-5366-9860-2',
+      summary: 'Literary reportage blending climate narratives with personal field diaries.',
+      preview:
+        'Essays weave metaphors from typhoon tracking data and oral histories collected along the coast.',
+      bookmarks: [38, 110],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'literature-3',
+      title: 'Echoes on Lushan Trail',
+      author: 'Zhang Mingwei',
+      classification: 'literature.poetry',
+      publicationYear: 2015,
+      format: 'pdf',
+      sizeMB: 3.1,
+      dateAdded: '2024-03-19',
+      enrichment: 'inprogress',
+      pages: 168,
+      progress: { currentPage: 98 },
+      isbn: '978-7-5302-9342-7',
+      summary: 'Bilingual poetry sequence inspired by misty mornings in Jiangxi.',
+      preview:
+        'Bamboo stanza forms echo classical cadences while layering contemporary environmental imagery.',
+      bookmarks: [12, 97, 146],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'literature-4',
+      title: 'Oral Histories of the Pearl Delta',
+      author: 'Luo Jia',
+      classification: 'literature.essay',
+      publicationYear: 2017,
+      format: 'txt',
+      sizeMB: 1.1,
+      dateAdded: '2024-02-02',
+      enrichment: 'complete',
+      pages: 342,
+      progress: { currentPage: 276 },
+      isbn: '978-7-108-06618-2',
+      summary: 'First-person recollections documenting delta transformations across generations.',
+      preview:
+        'Transcripts reveal dialect variations and migratory patterns, with inline translator annotations.',
+      bookmarks: [64, 241, 322],
+      tts: true,
+      exportable: true
+    }
+  ]
+};
+
+const initialBookmarks = Object.values(initialCollectionBooks)
+  .flat()
+  .reduce((map, book) => {
+    map[book.id] = new Set(book.bookmarks || []);
+    return map;
+  }, {});
+
+const initialPreviewStates = Object.values(initialCollectionBooks)
+  .flat()
+  .reduce((map, book) => {
+    map[book.id] = {
+      page: book.progress?.currentPage || 1,
+      zoom: 1,
+      fit: 'width',
+      fullscreen: false
+    };
+    return map;
+  }, {});
+
+const initialSettings = {
+  metadataSources: 'Douban, OpenLibrary',
+  apiKey: '',
+  rateLimit: 60,
+  proxy: '',
+  cachePath: '~/Library/Application Support/LocalBookshelf/covers',
+  previewPath: '~/Library/Application Support/LocalBookshelf/previews',
+  embeddingsPath: '~/Library/Application Support/LocalBookshelf/embeddings',
+  paginationDefault: 20,
+  theme: 'system',
+  analytics: true,
+  offline: false
+};
+
+let jobCounter = 0;
+
+const state = {
+  locale: 'en',
+  showWizard: false,
+  wizardStep: 0,
+  wizardData: {
+    mode: 'create',
+    targetId: null,
+    paths: [],
+    name: '',
+    description: '',
+    coverName: '',
+    coverFile: null
+  },
+  wizardErrors: [],
+  userCollections: [],
+  collectionOverrides: {},
+  collectionMeta: JSON.parse(JSON.stringify(initialCollectionMetadata)),
+  collectionBooks: JSON.parse(JSON.stringify(initialCollectionBooks)),
+  monitorOpen: false,
+  settingsOpen: false,
+  selectedCollectionId: null,
+  selectedBookId: null,
+  preferences: {},
+  bookmarks: Object.keys(initialBookmarks).reduce((map, id) => {
+    map[id] = new Set(initialBookmarks[id]);
+    return map;
+  }, {}),
+  previewStates: initialPreviewStates,
+  ttsState: { playing: false, voice: 'female', speed: 1, highlight: true },
+  exportState: { destination: '~/Documents/Local-Bookshelf/Exports', includeMetadata: true, status: 'idle', progress: 0 },
+  aiSessions: {},
+  jobs: [],
+  toast: null,
+  settings: { ...initialSettings }
+};
 
 function createElement(tag, options = {}) {
   const element = document.createElement(tag);
@@ -21,16 +434,477 @@ function createElement(tag, options = {}) {
   }
   if (options.children) {
     options.children.forEach((child) => {
-      element.appendChild(child);
+      if (child) {
+        element.appendChild(child);
+      }
     });
   }
   return element;
 }
 
+function getPack() {
+  return translations[state.locale];
+}
+
+function formatDate(dateString) {
+  if (!dateString) {
+    return state.locale === 'zh' ? '暂无记录' : 'No record';
+  }
+  const date = typeof dateString === 'string' ? new Date(dateString) : dateString;
+  return date.toLocaleString(state.locale === 'zh' ? 'zh-CN' : 'en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+function formatSize(sizeMB) {
+  if (sizeMB >= 1024) {
+    return `${(sizeMB / 1024).toFixed(1)} GB`;
+  }
+  return `${sizeMB.toFixed(1)} MB`;
+}
+
+function getClassificationLabel(key) {
+  const labels = classificationCatalog[key];
+  if (!labels) {
+    return key;
+  }
+  return labels[state.locale] || labels.en;
+}
+
+function getFormatLabel(key) {
+  const labels = formatCatalog[key];
+  if (!labels) {
+    return key.toUpperCase();
+  }
+  return labels[state.locale] || labels.en;
+}
+
+function getEnrichmentLabel(key) {
+  const labels = enrichmentLabels[key];
+  if (!labels) {
+    return key;
+  }
+  return labels[state.locale] || labels.en;
+}
+
+function deepCloneBooks(books) {
+  return JSON.parse(JSON.stringify(books));
+}
+
+function getCollectionDisplay(id) {
+  const pack = getPack();
+  if (id === 'new-collection') {
+    return {
+      id,
+      title: state.locale === 'zh' ? '创建新收藏集' : 'New Collection',
+      description:
+        state.locale === 'zh'
+          ? '打开多步骤向导，添加文件夹、元数据与封面。'
+          : 'Launch the creation wizard to add folders, metadata, and a custom cover.',
+      stats:
+        state.locale === 'zh' ? '向导 · 拖放路径 · 自动扫描' : 'Wizard · Drag & Drop Paths · Auto Scan',
+      actions: [pack.newCollectionLabel]
+    };
+  }
+  const overrides = state.collectionOverrides[id];
+  const basePack = translations[state.locale].collections.find((item) => item.id === id);
+  const user = state.userCollections.find((item) => item.id === id);
+  if (user) {
+    return {
+      id,
+      title: user.names[state.locale] || user.names.en,
+      description: user.descriptions[state.locale] || user.descriptions.en,
+      stats: user.stats[state.locale] || user.stats.en,
+      actions: user.actions[state.locale] || user.actions.en
+    };
+  }
+  if (!basePack) {
+    return null;
+  }
+  return {
+    id,
+    title: overrides?.names?.[state.locale] || overrides?.name || basePack.title,
+    description: overrides?.descriptions?.[state.locale] || overrides?.description || basePack.description,
+    stats: overrides?.stats?.[state.locale] || overrides?.stats?.en || basePack.stats,
+    actions: basePack.actions
+  };
+}
+
+function getCollectionList() {
+  const baseOrder = ['new-collection', 'climate', 'design', 'literature'];
+  const baseCards = baseOrder.map((id) => getCollectionDisplay(id)).filter(Boolean);
+  const userCards = state.userCollections
+    .filter((item) => !baseOrder.includes(item.id))
+    .map((item) => getCollectionDisplay(item.id));
+  return [...baseCards, ...userCards];
+}
+
+function ensurePreferences(collectionId) {
+  if (!state.preferences[collectionId]) {
+    const meta = state.collectionMeta[collectionId] || {};
+    state.preferences[collectionId] = {
+      viewMode: 'cards',
+      pageSize: meta.pagination || state.settings.paginationDefault,
+      page: 1,
+      search: '',
+      classification: 'all',
+      format: 'all',
+      yearFrom: 2000,
+      yearTo: new Date().getFullYear(),
+      selected: new Set(),
+      sort: { column: 'title', direction: 'asc' }
+    };
+  }
+  return state.preferences[collectionId];
+}
+
+function getBooks(collectionId) {
+  if (!state.collectionBooks[collectionId]) {
+    state.collectionBooks[collectionId] = deepCloneBooks(initialCollectionBooks.design || []);
+  }
+  return state.collectionBooks[collectionId];
+}
+
+function getPreviewState(bookId, defaultPage = 1) {
+  if (!state.previewStates[bookId]) {
+    state.previewStates[bookId] = {
+      page: defaultPage,
+      zoom: 1,
+      fit: 'width',
+      fullscreen: false
+    };
+  }
+  return state.previewStates[bookId];
+}
+
+function getBookmarks(bookId) {
+  if (!state.bookmarks[bookId]) {
+    state.bookmarks[bookId] = new Set();
+  }
+  return state.bookmarks[bookId];
+}
+
+function setSelectedCollection(collectionId) {
+  state.selectedCollectionId = collectionId;
+  const books = getBooks(collectionId);
+  if (books.length) {
+    state.selectedBookId = books[0].id;
+    const preview = getPreviewState(state.selectedBookId, books[0].progress?.currentPage || 1);
+    preview.page = books[0].progress?.currentPage || 1;
+    preview.zoom = 1;
+    preview.fit = 'width';
+  }
+  ensurePreferences(collectionId);
+  renderApp();
+}
+
+function setSelectedBook(bookId) {
+  state.selectedBookId = bookId;
+  const book = findBookById(bookId);
+  if (book) {
+    const preview = getPreviewState(bookId, book.progress?.currentPage || 1);
+    preview.page = book.progress?.currentPage || 1;
+    preview.zoom = 1;
+    preview.fit = 'width';
+  }
+  renderApp();
+}
+
+function findBookById(bookId) {
+  for (const collectionId of Object.keys(state.collectionBooks)) {
+    const book = state.collectionBooks[collectionId].find((item) => item.id === bookId);
+    if (book) {
+      return book;
+    }
+  }
+  return null;
+}
+
+function doesCollectionNameExist(name, ignoreId = null) {
+  if (!name) {
+    return false;
+  }
+  const normalized = name.trim().toLowerCase();
+  const existing = [...state.userCollections.map((item) => ({ id: item.id, names: item.names }))];
+  ['climate', 'design', 'literature'].forEach((id) => {
+    const card = getCollectionDisplay(id);
+    if (card) {
+      existing.push({ id, names: { en: card.title, zh: card.title } });
+    }
+  });
+  return existing.some((entry) => {
+    if (ignoreId && entry.id === ignoreId) {
+      return false;
+    }
+    return Object.values(entry.names || {})
+      .filter(Boolean)
+      .some((value) => value.trim().toLowerCase() === normalized);
+  });
+}
+
+function showToast(message) {
+  state.toast = { message, timestamp: Date.now() };
+  renderApp();
+  setTimeout(() => {
+    if (state.toast && Date.now() - state.toast.timestamp >= 2600) {
+      state.toast = null;
+      renderApp();
+    }
+  }, 2800);
+}
+function createJob({ type, collectionId, label, onComplete }) {
+  const job = {
+    id: `job-${Date.now()}-${jobCounter++}`,
+    type,
+    collectionId,
+    label,
+    progress: 0,
+    status: 'queued',
+    updatedAt: new Date(),
+    onComplete
+  };
+  state.jobs.unshift(job);
+  renderApp();
+  setTimeout(() => startJob(job), 300);
+  return job;
+}
+
+function startJob(job) {
+  if (!job) {
+    return;
+  }
+  job.status = 'running';
+  job.updatedAt = new Date();
+  renderApp();
+  advanceJob(job);
+}
+
+function advanceJob(job) {
+  if (!job || job.status !== 'running') {
+    return;
+  }
+  if (job.progress >= 100) {
+    job.progress = 100;
+    job.status = 'completed';
+    job.updatedAt = new Date();
+    renderApp();
+    if (typeof job.onComplete === 'function') {
+      job.onComplete();
+    }
+    return;
+  }
+  const increment = Math.min(100 - job.progress, Math.round(Math.random() * 15) + 10);
+  job.progress += increment;
+  job.updatedAt = new Date();
+  renderApp();
+  setTimeout(() => advanceJob(job), 600 + Math.random() * 400);
+}
+
+function generateBooksForNewCollection(collectionId, name) {
+  const base = deepCloneBooks(initialCollectionBooks.design);
+  return base.map((book, index) => ({
+    ...book,
+    id: `${collectionId}-book-${index + 1}`,
+    title: `${name} · ${book.title}`,
+    progress: { currentPage: Math.min(book.progress?.currentPage || 1, book.pages) }
+  }));
+}
+
+function openWizard(mode = 'create', targetId = null) {
+  const pack = getPack();
+  state.showWizard = true;
+  state.wizardStep = 0;
+  state.wizardErrors = [];
+  state.wizardData = {
+    mode,
+    targetId,
+    paths: [],
+    name: '',
+    description: '',
+    coverName: '',
+    coverFile: null
+  };
+  if (mode === 'edit' && targetId) {
+    const display = getCollectionDisplay(targetId);
+    const meta = state.collectionMeta[targetId] || { directories: [] };
+    state.wizardData.paths = [...meta.directories];
+    state.wizardData.name = display?.title || '';
+    state.wizardData.description = display?.description || '';
+    state.wizardData.coverName = state.collectionOverrides[targetId]?.coverName || '';
+  }
+  renderApp();
+}
+
+function closeWizard() {
+  state.showWizard = false;
+  state.wizardErrors = [];
+  renderApp();
+}
+
+function validateWizardStep(step) {
+  const pack = getPack();
+  const errors = [];
+  if (step === 0 && state.wizardData.paths.length === 0) {
+    errors.push(pack.wizard.validations.missingPaths);
+  }
+  if (step === 1) {
+    if (!state.wizardData.name.trim()) {
+      errors.push(pack.wizard.validations.missingName);
+    } else if (
+      state.wizardData.mode === 'create' &&
+      doesCollectionNameExist(state.wizardData.name)
+    ) {
+      errors.push(pack.wizard.validations.duplicateName);
+    } else if (
+      state.wizardData.mode === 'edit' &&
+      doesCollectionNameExist(state.wizardData.name, state.wizardData.targetId)
+    ) {
+      errors.push(pack.wizard.validations.duplicateName);
+    }
+  }
+  if (step === 2 && state.wizardData.coverFile) {
+    if (!supportedCoverTypes.includes(state.wizardData.coverFile.type)) {
+      errors.push(pack.wizard.validations.invalidCover);
+    }
+  }
+  state.wizardErrors = errors;
+  renderApp();
+  return errors.length === 0;
+}
+
+function completeWizard() {
+  if (!validateWizardStep(1)) {
+    return;
+  }
+  const pack = getPack();
+  if (state.wizardData.mode === 'create') {
+    const collectionId = `collection-${Date.now()}`;
+    const name = state.wizardData.name.trim();
+    const description = state.wizardData.description.trim();
+    const newCollection = {
+      id: collectionId,
+      names: { en: name, zh: name },
+      descriptions: { en: description, zh: description },
+      stats: {
+        en: '120 books · Initial scan pending',
+        zh: '120 本 · 等待首次扫描'
+      },
+      actions: {
+        en: ['Resume Reading', 'Open AI Chat', 'Rescan'],
+        zh: ['继续阅读', '开启 AI 对话', '重新扫描']
+      }
+    };
+    state.userCollections.push(newCollection);
+    state.collectionMeta[collectionId] = {
+      directories: [...state.wizardData.paths],
+      lastScan: new Date().toISOString(),
+      pagination: state.settings.paginationDefault,
+      aiEnabled: true
+    };
+    state.collectionBooks[collectionId] = generateBooksForNewCollection(collectionId, name);
+    const firstBook = state.collectionBooks[collectionId][0];
+    if (firstBook) {
+      state.previewStates[firstBook.id] = {
+        page: firstBook.progress?.currentPage || 1,
+        zoom: 1,
+        fit: 'width',
+        fullscreen: false
+      };
+      state.bookmarks[firstBook.id] = new Set(firstBook.bookmarks || []);
+    }
+    state.collectionOverrides[collectionId] = {
+      names: { en: name, zh: name },
+      descriptions: { en: description, zh: description },
+      stats: {
+        en: '120 books · Initial scan pending',
+        zh: '120 本 · 等待首次扫描'
+      },
+      coverName: state.wizardData.coverName,
+      paths: [...state.wizardData.paths]
+    };
+    showToast(pack.wizard.successTitle);
+    createJob({
+      type: 'scan',
+      collectionId,
+      label: `${name} · Initial scan`,
+      onComplete: () => {
+        state.collectionOverrides[collectionId].stats = {
+          en: '120 books · Scan completed just now',
+          zh: '120 本 · 扫描刚刚完成'
+        };
+        state.collectionMeta[collectionId].lastScan = new Date().toISOString();
+        renderApp();
+      }
+    });
+    closeWizard();
+    setSelectedCollection(collectionId);
+    return;
+  }
+  if (state.wizardData.mode === 'edit' && state.wizardData.targetId) {
+    const targetId = state.wizardData.targetId;
+    const overrides = state.collectionOverrides[targetId] || {};
+    state.collectionOverrides[targetId] = {
+      ...overrides,
+      names: { en: state.wizardData.name.trim(), zh: state.wizardData.name.trim() },
+      descriptions: { en: state.wizardData.description.trim(), zh: state.wizardData.description.trim() },
+      coverName: state.wizardData.coverName,
+      paths: [...state.wizardData.paths]
+    };
+    state.collectionMeta[targetId] = state.collectionMeta[targetId] || {};
+    state.collectionMeta[targetId].directories = [...state.wizardData.paths];
+    showToast(pack.settings.saved);
+    createJob({
+      type: 'scan',
+      collectionId: targetId,
+      label: `${state.wizardData.name.trim()} · Rescan`,
+      onComplete: () => {
+        state.collectionMeta[targetId].lastScan = new Date().toISOString();
+        renderApp();
+      }
+    });
+    closeWizard();
+  }
+}
+function switchLocale(locale) {
+  if (locale === state.locale) {
+    return;
+  }
+  if (!translations[locale]) {
+    return;
+  }
+  state.locale = locale;
+  renderApp();
+}
+
 function renderTopBar(pack) {
-  const titleGroup = createElement('div');
+  const titleGroup = createElement('div', { className: 'hero-group' });
   titleGroup.appendChild(createElement('h1', { text: pack.heroTitle }));
   titleGroup.appendChild(createElement('p', { text: pack.heroSubtitle }));
+
+  const actions = createElement('div', { className: 'action-group' });
+  const monitorButton = createElement('button', {
+    className: `pill-button${state.monitorOpen ? ' active' : ''}`,
+    text: pack.actionBar.toggleMonitor
+  });
+  monitorButton.type = 'button';
+  monitorButton.addEventListener('click', () => {
+    state.monitorOpen = !state.monitorOpen;
+    renderApp();
+  });
+
+  const settingsButton = createElement('button', {
+    className: `pill-button${state.settingsOpen ? ' active' : ''}`,
+    text: pack.actionBar.openSettings
+  });
+  settingsButton.type = 'button';
+  settingsButton.addEventListener('click', () => {
+    state.settingsOpen = !state.settingsOpen;
+    renderApp();
+  });
 
   const toggle = createElement('div', {
     className: 'language-toggle',
@@ -40,14 +914,14 @@ function renderTopBar(pack) {
 
   const englishButton = createElement('button', {
     text: 'English',
-    className: currentLocale === 'en' ? 'active' : ''
+    className: state.locale === 'en' ? 'active' : ''
   });
   englishButton.type = 'button';
   englishButton.addEventListener('click', () => switchLocale('en'));
 
   const chineseButton = createElement('button', {
     text: '中文',
-    className: currentLocale === 'zh' ? 'active' : ''
+    className: state.locale === 'zh' ? 'active' : ''
   });
   chineseButton.type = 'button';
   chineseButton.addEventListener('click', () => switchLocale('zh'));
@@ -55,9 +929,13 @@ function renderTopBar(pack) {
   toggle.appendChild(englishButton);
   toggle.appendChild(chineseButton);
 
+  actions.appendChild(monitorButton);
+  actions.appendChild(settingsButton);
+  actions.appendChild(toggle);
+
   return createElement('header', {
     className: 'top-bar',
-    children: [titleGroup, toggle]
+    children: [titleGroup, actions]
   });
 }
 
@@ -66,7 +944,6 @@ function renderStats(pack) {
     className: 'dashboard-grid',
     attributes: { 'aria-label': 'dashboard' }
   });
-
   pack.stats.forEach((stat) => {
     const card = createElement('article', { className: 'dashboard-card' });
     card.appendChild(createElement('h3', { text: stat.label }));
@@ -74,8 +951,50 @@ function renderStats(pack) {
     card.appendChild(createElement('p', { text: stat.helper }));
     statsGrid.appendChild(card);
   });
-
   return statsGrid;
+}
+
+function handleCollectionAction(collectionId, actionLabel) {
+  const pack = getPack();
+  const normalized = actionLabel.trim();
+  const resumeLabels = [pack.collectionDetail.resumeReading, 'Resume Reading', '继续阅读'];
+  const previewLabels = [pack.collectionDetail.cardActions.preview, 'Preview Library', '预览文库'];
+  const exportLabels = [pack.collectionDetail.cardActions.export, 'Export PDF Set', '批量导出 PDF'];
+  const chatLabels = [pack.collectionDetail.cardActions.chat, 'Open AI Chat', '开启 AI 对话'];
+  const editLabels = ['Edit', '编辑'];
+  const rescanLabels = [pack.collectionDetail.rescan, '重新扫描'];
+  if (resumeLabels.includes(normalized) || previewLabels.includes(normalized)) {
+    setSelectedCollection(collectionId);
+    return;
+  }
+  if (chatLabels.includes(normalized)) {
+    setSelectedCollection(collectionId);
+    ensureAiSession(collectionId);
+    return;
+  }
+  if (exportLabels.includes(normalized)) {
+    setSelectedCollection(collectionId);
+    startExport(getBooks(collectionId).map((book) => book.id));
+    return;
+  }
+  if (editLabels.includes(normalized)) {
+    openWizard('edit', collectionId);
+    return;
+  }
+  if (rescanLabels.includes(normalized)) {
+    const display = getCollectionDisplay(collectionId);
+    createJob({
+      type: 'scan',
+      collectionId,
+      label: `${display?.title || collectionId} · Rescan`,
+      onComplete: () => {
+        state.collectionMeta[collectionId] = state.collectionMeta[collectionId] || {};
+        state.collectionMeta[collectionId].lastScan = new Date().toISOString();
+        showToast(state.locale === 'zh' ? '扫描已完成' : 'Scan completed');
+        renderApp();
+      }
+    });
+  }
 }
 
 function renderCollections(pack) {
@@ -85,25 +1004,33 @@ function renderCollections(pack) {
   header.appendChild(createElement('p', { text: pack.collectionsSubtitle }));
 
   const grid = createElement('div', { className: 'collection-grid' });
-
-  pack.collections.forEach((collection) => {
+  const collections = getCollectionList();
+  collections.forEach((collection) => {
     const isNew = collection.id === 'new-collection';
     const card = createElement('div', {
       className: `collection-card${isNew ? ' new-collection-card' : ''}`
     });
-
     card.appendChild(createElement('h4', { text: collection.title }));
     card.appendChild(createElement('p', { text: collection.description }));
     card.appendChild(createElement('p', { text: collection.stats }));
-
     const actionRow = createElement('div', { className: 'collection-actions' });
     collection.actions.forEach((action) => {
       const button = createElement('button', { text: action });
       button.type = 'button';
+      button.addEventListener('click', (event) => {
+        event.stopPropagation();
+        if (isNew) {
+          openWizard('create');
+          return;
+        }
+        handleCollectionAction(collection.id, action);
+      });
       actionRow.appendChild(button);
     });
+    if (!isNew) {
+      card.addEventListener('click', () => setSelectedCollection(collection.id));
+    }
     card.appendChild(actionRow);
-
     grid.appendChild(card);
   });
 
@@ -120,39 +1047,1293 @@ function renderRoadmap(pack) {
       children: [createElement('h2', { text: pack.roadmapTitle })]
     })
   );
-
   const grid = createElement('div', { className: 'dashboard-grid multi-column' });
   pack.roadmapItems.forEach((item) => {
     const card = createElement('article', { className: 'dashboard-card' });
     card.appendChild(createElement('p', { text: item }));
     grid.appendChild(card);
   });
-
   section.appendChild(grid);
   return section;
 }
+function renderFilters(collectionId, preferences, pack) {
+  const filters = createElement('div', { className: 'filters-panel' });
+  const searchInput = createElement('input', {
+    className: 'search-input',
+    attributes: { type: 'search', placeholder: pack.collectionDetail.searchPlaceholder }
+  });
+  searchInput.value = preferences.search;
+  searchInput.addEventListener('input', (event) => {
+    preferences.search = event.target.value;
+    preferences.page = 1;
+    renderApp();
+  });
+
+  const classificationSelect = createElement('select', { className: 'filter-select' });
+  const allOption = createElement('option', {
+    text: state.locale === 'zh' ? '全部分类' : 'All classifications'
+  });
+  allOption.value = 'all';
+  classificationSelect.appendChild(allOption);
+  classificationOptions.forEach((option) => {
+    const node = createElement('option', { text: getClassificationLabel(option) });
+    node.value = option;
+    if (preferences.classification === option) {
+      node.selected = true;
+    }
+    classificationSelect.appendChild(node);
+  });
+  classificationSelect.value = preferences.classification;
+  classificationSelect.addEventListener('change', (event) => {
+    preferences.classification = event.target.value;
+    preferences.page = 1;
+    renderApp();
+  });
+
+  const formatSelect = createElement('select', { className: 'filter-select' });
+  const allFormat = createElement('option', {
+    text: state.locale === 'zh' ? '全部格式' : 'All formats'
+  });
+  allFormat.value = 'all';
+  formatSelect.appendChild(allFormat);
+  formatOptions.forEach((option) => {
+    const node = createElement('option', { text: getFormatLabel(option) });
+    node.value = option;
+    if (preferences.format === option) {
+      node.selected = true;
+    }
+    formatSelect.appendChild(node);
+  });
+  formatSelect.value = preferences.format;
+  formatSelect.addEventListener('change', (event) => {
+    preferences.format = event.target.value;
+    preferences.page = 1;
+    renderApp();
+  });
+
+  const yearContainer = createElement('div', { className: 'year-filter' });
+  const fromInput = createElement('input', {
+    attributes: { type: 'number', min: 1900, max: new Date().getFullYear() }
+  });
+  fromInput.value = preferences.yearFrom;
+  fromInput.addEventListener('change', (event) => {
+    preferences.yearFrom = Number(event.target.value) || preferences.yearFrom;
+    preferences.page = 1;
+    renderApp();
+  });
+  const toInput = createElement('input', {
+    attributes: { type: 'number', min: 1900, max: new Date().getFullYear() }
+  });
+  toInput.value = preferences.yearTo;
+  toInput.addEventListener('change', (event) => {
+    preferences.yearTo = Number(event.target.value) || preferences.yearTo;
+    preferences.page = 1;
+    renderApp();
+  });
+  yearContainer.appendChild(createElement('label', { text: pack.collectionDetail.filters.publication }));
+  yearContainer.appendChild(
+    createElement('div', {
+      className: 'year-inputs',
+      children: [
+        createElement('span', { text: pack.collectionDetail.filters.from }),
+        fromInput,
+        createElement('span', { text: pack.collectionDetail.filters.to }),
+        toInput
+      ]
+    })
+  );
+
+  const resetButton = createElement('button', {
+    className: 'ghost-button',
+    text: pack.collectionDetail.filters.reset
+  });
+  resetButton.type = 'button';
+  resetButton.addEventListener('click', () => {
+    preferences.search = '';
+    preferences.classification = 'all';
+    preferences.format = 'all';
+    preferences.yearFrom = 2000;
+    preferences.yearTo = new Date().getFullYear();
+    preferences.page = 1;
+    renderApp();
+  });
+
+  filters.appendChild(searchInput);
+  filters.appendChild(
+    createElement('div', {
+      className: 'filter-row',
+      children: [
+        createElement('label', { text: pack.collectionDetail.filters.classification }),
+        classificationSelect,
+        createElement('label', { text: pack.collectionDetail.filters.format }),
+        formatSelect,
+        yearContainer,
+        resetButton
+      ]
+    })
+  );
+  return filters;
+}
+
+function applyBookFilters(books, preferences) {
+  return books
+    .filter((book) => {
+      if (preferences.classification !== 'all' && book.classification !== preferences.classification) {
+        return false;
+      }
+      if (preferences.format !== 'all' && book.format !== preferences.format) {
+        return false;
+      }
+      if (preferences.yearFrom && book.publicationYear < preferences.yearFrom) {
+        return false;
+      }
+      if (preferences.yearTo && book.publicationYear > preferences.yearTo) {
+        return false;
+      }
+      if (!preferences.search) {
+        return true;
+      }
+      const value = preferences.search.trim().toLowerCase();
+      return (
+        book.title.toLowerCase().includes(value) ||
+        book.author.toLowerCase().includes(value) ||
+        (book.summary && book.summary.toLowerCase().includes(value))
+      );
+    })
+    .sort((a, b) => {
+      const { column, direction } = preferences.sort;
+      let compare = 0;
+      if (column === 'title') {
+        compare = a.title.localeCompare(b.title);
+      } else if (column === 'author') {
+        compare = a.author.localeCompare(b.author);
+      } else if (column === 'year') {
+        compare = a.publicationYear - b.publicationYear;
+      } else if (column === 'format') {
+        compare = a.format.localeCompare(b.format);
+      } else if (column === 'size') {
+        compare = a.sizeMB - b.sizeMB;
+      } else if (column === 'enrichment') {
+        compare = a.enrichment.localeCompare(b.enrichment);
+      }
+      return direction === 'asc' ? compare : -compare;
+    });
+}
+
+function toggleSort(preferences, column) {
+  if (preferences.sort.column === column) {
+    preferences.sort.direction = preferences.sort.direction === 'asc' ? 'desc' : 'asc';
+  } else {
+    preferences.sort.column = column;
+    preferences.sort.direction = 'asc';
+  }
+  renderApp();
+}
+
+function renderCardView(books, preferences, pack) {
+  const grid = createElement('div', { className: 'book-card-grid' });
+  if (!books.length) {
+    grid.appendChild(createElement('p', { className: 'empty-state', text: pack.collectionDetail.noResults }));
+    return grid;
+  }
+  books.forEach((book) => {
+    const card = createElement('article', { className: 'book-card' });
+    const header = createElement('div', { className: 'book-card-header' });
+    const checkbox = createElement('input', {
+      attributes: { type: 'checkbox', 'aria-label': book.title }
+    });
+    checkbox.checked = preferences.selected.has(book.id);
+    checkbox.addEventListener('change', (event) => {
+      if (event.target.checked) {
+        preferences.selected.add(book.id);
+      } else {
+        preferences.selected.delete(book.id);
+      }
+      renderApp();
+    });
+    header.appendChild(checkbox);
+    header.appendChild(createElement('h3', { text: book.title }));
+    card.appendChild(header);
+    card.appendChild(
+      createElement('p', {
+        className: 'book-meta',
+        text: `${book.author} · ${getClassificationLabel(book.classification)} · ${book.publicationYear}`
+      })
+    );
+    card.appendChild(createElement('p', { className: 'book-summary', text: book.summary }));
+    const progress = Math.round((book.progress?.currentPage || 1) / book.pages * 100);
+    card.appendChild(
+      createElement('div', {
+        className: 'progress-bar',
+        children: [
+          createElement('span', { text: `${progress}%` }),
+          createElement('div', {
+            className: 'progress-track',
+            children: [
+              createElement('div', {
+                className: 'progress-fill',
+                attributes: { style: `width: ${progress}%` }
+              })
+            ]
+          })
+        ]
+      })
+    );
+    const actionRow = createElement('div', { className: 'collection-actions' });
+    const previewButton = createElement('button', { text: pack.collectionDetail.cardActions.preview });
+    previewButton.type = 'button';
+    previewButton.addEventListener('click', () => setSelectedBook(book.id));
+    const exportButton = createElement('button', { text: pack.collectionDetail.cardActions.export });
+    exportButton.type = 'button';
+    exportButton.addEventListener('click', () => startExport([book.id]));
+    const chatButton = createElement('button', { text: pack.collectionDetail.cardActions.chat });
+    chatButton.type = 'button';
+    chatButton.addEventListener('click', () => {
+      ensureAiSession(state.selectedCollectionId);
+      sendAiMessage(state.selectedCollectionId, `${book.title} summary`);
+    });
+    actionRow.appendChild(previewButton);
+    actionRow.appendChild(exportButton);
+    actionRow.appendChild(chatButton);
+    card.appendChild(actionRow);
+    card.addEventListener('click', (event) => {
+      if (event.target.tagName.toLowerCase() === 'input' || event.target.tagName.toLowerCase() === 'button') {
+        return;
+      }
+      setSelectedBook(book.id);
+    });
+    grid.appendChild(card);
+  });
+  return grid;
+}
+
+function renderTableView(books, preferences, pack) {
+  const wrapper = createElement('div', { className: 'table-wrapper' });
+  if (!books.length) {
+    wrapper.appendChild(createElement('p', { className: 'empty-state', text: pack.collectionDetail.noResults }));
+    return wrapper;
+  }
+  const table = createElement('table', { className: 'book-table' });
+  const thead = createElement('thead');
+  const headerRow = createElement('tr');
+
+  const selectHeader = createElement('th');
+  selectHeader.appendChild(createElement('span', { text: '#' }));
+  headerRow.appendChild(selectHeader);
+
+  const headers = [
+    { key: 'title', label: pack.collectionDetail.tableHeaders[0] },
+    { key: 'author', label: pack.collectionDetail.tableHeaders[1] },
+    { key: 'classification', label: pack.collectionDetail.tableHeaders[2] },
+    { key: 'year', label: pack.collectionDetail.tableHeaders[3] },
+    { key: 'format', label: pack.collectionDetail.tableHeaders[4] },
+    { key: 'size', label: pack.collectionDetail.tableHeaders[5] },
+    { key: 'dateAdded', label: pack.collectionDetail.tableHeaders[6] },
+    { key: 'enrichment', label: pack.collectionDetail.tableHeaders[7] }
+  ];
+
+  headers.forEach((header) => {
+    const th = createElement('th');
+    const button = createElement('button', {
+      className: 'table-sort',
+      text: header.label
+    });
+    button.type = 'button';
+    button.addEventListener('click', () => toggleSort(preferences, header.key));
+    if (preferences.sort.column === header.key) {
+      button.classList.add(preferences.sort.direction === 'asc' ? 'sort-asc' : 'sort-desc');
+    }
+    th.appendChild(button);
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = createElement('tbody');
+  books.forEach((book) => {
+    const row = createElement('tr');
+    const checkboxCell = createElement('td');
+    const checkbox = createElement('input', { attributes: { type: 'checkbox', 'aria-label': book.title } });
+    checkbox.checked = preferences.selected.has(book.id);
+    checkbox.addEventListener('change', (event) => {
+      if (event.target.checked) {
+        preferences.selected.add(book.id);
+      } else {
+        preferences.selected.delete(book.id);
+      }
+      renderApp();
+    });
+    checkboxCell.appendChild(checkbox);
+    row.appendChild(checkboxCell);
+
+    const values = [
+      book.title,
+      book.author,
+      getClassificationLabel(book.classification),
+      book.publicationYear,
+      getFormatLabel(book.format),
+      formatSize(book.sizeMB),
+      formatDate(book.dateAdded),
+      getEnrichmentLabel(book.enrichment)
+    ];
+    values.forEach((value) => {
+      const cell = createElement('td', { text: value });
+      row.appendChild(cell);
+    });
+    row.addEventListener('click', (event) => {
+      if (event.target.tagName.toLowerCase() === 'input') {
+        return;
+      }
+      setSelectedBook(book.id);
+    });
+    tbody.appendChild(row);
+  });
+  table.appendChild(tbody);
+  wrapper.appendChild(table);
+  return wrapper;
+}
+
+function renderPaginationControls(preferences, totalItems, pack) {
+  const container = createElement('div', { className: 'pagination-controls' });
+  const totalPages = Math.max(1, Math.ceil(totalItems / preferences.pageSize));
+  if (preferences.page > totalPages) {
+    preferences.page = totalPages;
+  }
+
+  const sizeSelect = createElement('select');
+  [10, 20, 50, 100, 200].forEach((value) => {
+    const option = createElement('option', { text: `${value}` });
+    option.value = value;
+    if (preferences.pageSize === value) {
+      option.selected = true;
+    }
+    sizeSelect.appendChild(option);
+  });
+  sizeSelect.addEventListener('change', (event) => {
+    preferences.pageSize = Number(event.target.value);
+    preferences.page = 1;
+    renderApp();
+  });
+
+  const prevButton = createElement('button', {
+    className: 'ghost-button',
+    text: pack.collectionDetail.pagination.previous
+  });
+  prevButton.type = 'button';
+  prevButton.disabled = preferences.page <= 1;
+  prevButton.addEventListener('click', () => {
+    if (preferences.page > 1) {
+      preferences.page -= 1;
+      renderApp();
+    }
+  });
+
+  const nextButton = createElement('button', {
+    className: 'ghost-button',
+    text: pack.collectionDetail.pagination.next
+  });
+  nextButton.type = 'button';
+  nextButton.disabled = preferences.page >= totalPages;
+  nextButton.addEventListener('click', () => {
+    if (preferences.page < totalPages) {
+      preferences.page += 1;
+      renderApp();
+    }
+  });
+
+  container.appendChild(createElement('span', { text: `${pack.collectionDetail.pagination.label}` }));
+  container.appendChild(sizeSelect);
+  container.appendChild(createElement('span', { text: `${preferences.page} / ${totalPages}` }));
+  container.appendChild(prevButton);
+  container.appendChild(nextButton);
+  return container;
+}
+
+function renderBulkActions(preferences, pack) {
+  const container = createElement('div', { className: 'bulk-actions' });
+  container.appendChild(createElement('span', { text: pack.collectionDetail.bulkActions.title }));
+  const selectAll = createElement('button', {
+    className: 'ghost-button',
+    text: pack.collectionDetail.bulkActions.selectAll
+  });
+  selectAll.type = 'button';
+  selectAll.addEventListener('click', () => {
+    const books = getBooks(state.selectedCollectionId);
+    books.forEach((book) => preferences.selected.add(book.id));
+    renderApp();
+  });
+  const clear = createElement('button', {
+    className: 'ghost-button',
+    text: pack.collectionDetail.bulkActions.clear
+  });
+  clear.type = 'button';
+  clear.addEventListener('click', () => {
+    preferences.selected.clear();
+    renderApp();
+  });
+  const refresh = createElement('button', { text: pack.collectionDetail.bulkActions.refreshMetadata });
+  refresh.type = 'button';
+  refresh.addEventListener('click', () => {
+    const ids = Array.from(preferences.selected);
+    if (!ids.length) {
+      showToast(state.locale === 'zh' ? '请选择至少一本书' : 'Select at least one book');
+      return;
+    }
+    const title = getCollectionDisplay(state.selectedCollectionId)?.title || '';
+    createJob({
+      type: 'enrichment',
+      collectionId: state.selectedCollectionId,
+      label: `${title} · Metadata refresh`,
+      onComplete: () => showToast(state.locale === 'zh' ? '元数据已刷新' : 'Metadata refreshed')
+    });
+  });
+  const exportButton = createElement('button', { text: pack.collectionDetail.bulkActions.export });
+  exportButton.type = 'button';
+  exportButton.addEventListener('click', () => {
+    const ids = Array.from(preferences.selected);
+    if (!ids.length) {
+      showToast(state.locale === 'zh' ? '请选择至少一本书' : 'Select at least one book');
+      return;
+    }
+    startExport(ids);
+  });
+  container.appendChild(selectAll);
+  container.appendChild(clear);
+  container.appendChild(refresh);
+  container.appendChild(exportButton);
+  return container;
+}
+function startExport(bookIds) {
+  if (!bookIds.length) {
+    return;
+  }
+  state.exportState.status = 'running';
+  state.exportState.progress = 0;
+  renderApp();
+  const incrementExport = () => {
+    if (state.exportState.status !== 'running') {
+      return;
+    }
+    if (state.exportState.progress >= 100) {
+      state.exportState.progress = 100;
+      state.exportState.status = 'completed';
+      createJob({
+        type: 'export',
+        collectionId: state.selectedCollectionId,
+        label: `${bookIds.length} book(s)`,
+        onComplete: () => {}
+      });
+      showToast(state.locale === 'zh' ? '导出完成' : 'Export completed');
+      renderApp();
+      return;
+    }
+    state.exportState.progress += Math.min(100 - state.exportState.progress, Math.round(Math.random() * 20) + 15);
+    renderApp();
+    setTimeout(incrementExport, 500 + Math.random() * 400);
+  };
+  setTimeout(incrementExport, 400);
+}
+
+function renderCollectionDetail(pack) {
+  const collectionId = state.selectedCollectionId;
+  if (!collectionId) {
+    return null;
+  }
+  const display = getCollectionDisplay(collectionId);
+  const meta = state.collectionMeta[collectionId] || { directories: [], lastScan: null };
+  const preferences = ensurePreferences(collectionId);
+  const books = applyBookFilters(getBooks(collectionId), preferences);
+  const startIndex = (preferences.page - 1) * preferences.pageSize;
+  const paginated = books.slice(startIndex, startIndex + preferences.pageSize);
+
+  const section = createElement('section', { className: 'detail-section' });
+  section.appendChild(createElement('h2', { text: `${pack.collectionDetail.titlePrefix}: ${display?.title || ''}` }));
+  section.appendChild(
+    createElement('p', {
+      className: 'detail-subtitle',
+      text: `${pack.collectionDetail.subtitle} · ${state.locale === 'zh' ? '最近扫描' : 'Last scan'}: ${formatDate(
+        meta.lastScan
+      )}`
+    })
+  );
+
+  const actionRow = createElement('div', { className: 'detail-actions' });
+  const rescan = createElement('button', { className: 'ghost-button', text: pack.collectionDetail.rescan });
+  rescan.type = 'button';
+  rescan.addEventListener('click', () => {
+    createJob({
+      type: 'scan',
+      collectionId,
+      label: `${display?.title || ''} · Rescan`,
+      onComplete: () => {
+        state.collectionMeta[collectionId] = state.collectionMeta[collectionId] || {};
+        state.collectionMeta[collectionId].lastScan = new Date().toISOString();
+        showToast(state.locale === 'zh' ? '扫描已完成' : 'Scan completed');
+        renderApp();
+      }
+    });
+  });
+  const refresh = createElement('button', { className: 'ghost-button', text: pack.collectionDetail.refresh });
+  refresh.type = 'button';
+  refresh.addEventListener('click', () => {
+    createJob({
+      type: 'enrichment',
+      collectionId,
+      label: `${display?.title || ''} · Metadata`,
+      onComplete: () => showToast(state.locale === 'zh' ? '元数据已刷新' : 'Metadata refreshed')
+    });
+  });
+  const chat = createElement('button', { className: 'ghost-button', text: pack.collectionDetail.openChat });
+  chat.type = 'button';
+  chat.addEventListener('click', () => {
+    ensureAiSession(collectionId);
+    renderApp();
+  });
+  actionRow.appendChild(rescan);
+  actionRow.appendChild(refresh);
+  actionRow.appendChild(chat);
+  section.appendChild(actionRow);
+
+  section.appendChild(renderFilters(collectionId, preferences, pack));
+
+  const layoutToggle = createElement('div', { className: 'layout-toggle' });
+  const cardButton = createElement('button', {
+    className: preferences.viewMode === 'cards' ? 'active' : '',
+    text: pack.collectionDetail.layoutToggle.cards
+  });
+  cardButton.type = 'button';
+  cardButton.addEventListener('click', () => {
+    preferences.viewMode = 'cards';
+    renderApp();
+  });
+  const tableButton = createElement('button', {
+    className: preferences.viewMode === 'table' ? 'active' : '',
+    text: pack.collectionDetail.layoutToggle.table
+  });
+  tableButton.type = 'button';
+  tableButton.addEventListener('click', () => {
+    preferences.viewMode = 'table';
+    renderApp();
+  });
+  layoutToggle.appendChild(cardButton);
+  layoutToggle.appendChild(tableButton);
+  section.appendChild(layoutToggle);
+
+  section.appendChild(renderBulkActions(preferences, pack));
+
+  if (preferences.viewMode === 'cards') {
+    section.appendChild(renderCardView(paginated, preferences, pack));
+  } else {
+    section.appendChild(renderTableView(paginated, preferences, pack));
+  }
+
+  section.appendChild(renderPaginationControls(preferences, books.length, pack));
+  return section;
+}
+
+function renderPreviewPanel(pack) {
+  const collectionId = state.selectedCollectionId;
+  if (!collectionId) {
+    return null;
+  }
+  const books = getBooks(collectionId);
+  if (!books.length) {
+    return null;
+  }
+  const book = books.find((item) => item.id === state.selectedBookId) || books[0];
+  const previewState = getPreviewState(book.id, book.progress?.currentPage || 1);
+  const panel = createElement('section', { className: 'preview-panel' });
+  panel.appendChild(createElement('h3', { text: pack.previewPanel.title }));
+  panel.appendChild(
+    createElement('p', {
+      className: 'preview-meta',
+      text: `${book.title} · ${book.author} · ${getFormatLabel(book.format)} · ${formatSize(book.sizeMB)}`
+    })
+  );
+
+  const controls = createElement('div', { className: 'preview-controls' });
+  const zoomOut = createElement('button', { text: pack.previewPanel.zoomOut });
+  zoomOut.type = 'button';
+  zoomOut.addEventListener('click', () => {
+    previewState.zoom = Math.max(0.5, previewState.zoom - 0.1);
+    renderApp();
+  });
+  const zoomIn = createElement('button', { text: pack.previewPanel.zoomIn });
+  zoomIn.type = 'button';
+  zoomIn.addEventListener('click', () => {
+    previewState.zoom = Math.min(2, previewState.zoom + 0.1);
+    renderApp();
+  });
+  const fitWidth = createElement('button', { text: pack.previewPanel.fitWidth });
+  fitWidth.type = 'button';
+  fitWidth.addEventListener('click', () => {
+    previewState.fit = 'width';
+    renderApp();
+  });
+  const fitPage = createElement('button', { text: pack.previewPanel.fitPage });
+  fitPage.type = 'button';
+  fitPage.addEventListener('click', () => {
+    previewState.fit = 'page';
+    renderApp();
+  });
+  const prevPage = createElement('button', { text: pack.previewPanel.previousPage });
+  prevPage.type = 'button';
+  prevPage.addEventListener('click', () => {
+    previewState.page = Math.max(1, previewState.page - 1);
+    renderApp();
+  });
+  const nextPage = createElement('button', { text: pack.previewPanel.nextPage });
+  nextPage.type = 'button';
+  nextPage.addEventListener('click', () => {
+    previewState.page = Math.min(book.pages, previewState.page + 1);
+    renderApp();
+  });
+  controls.appendChild(zoomOut);
+  controls.appendChild(zoomIn);
+  controls.appendChild(fitWidth);
+  controls.appendChild(fitPage);
+  controls.appendChild(prevPage);
+  controls.appendChild(nextPage);
+  panel.appendChild(controls);
+
+  panel.appendChild(
+    createElement('p', {
+      className: 'preview-page',
+      text: `${pack.previewPanel.currentPage} ${previewState.page} ${pack.previewPanel.of} ${book.pages}`
+    })
+  );
+
+  const content = createElement('div', {
+    className: `preview-content fit-${previewState.fit}${state.ttsState.playing && state.ttsState.highlight ? ' tts-active' : ''}`,
+    text: book.preview
+  });
+  content.style.transform = `scale(${previewState.zoom})`;
+  panel.appendChild(content);
+
+  const bookmarks = getBookmarks(book.id);
+  const bookmarkButton = createElement('button', {
+    text: bookmarks.has(previewState.page) ? pack.previewPanel.removeBookmark : pack.previewPanel.addBookmark
+  });
+  bookmarkButton.type = 'button';
+  bookmarkButton.addEventListener('click', () => {
+    if (bookmarks.has(previewState.page)) {
+      bookmarks.delete(previewState.page);
+      showToast(pack.previewPanel.removedBookmark);
+    } else {
+      bookmarks.add(previewState.page);
+      showToast(pack.previewPanel.savedBookmark);
+    }
+    renderApp();
+  });
+  panel.appendChild(bookmarkButton);
+
+  panel.appendChild(renderTtsPanel(pack, book));
+  panel.appendChild(renderExportPanel(pack, [book.id]));
+  return panel;
+}
+
+function renderTtsPanel(pack, book) {
+  const container = createElement('div', { className: 'tts-panel' });
+  container.appendChild(createElement('h4', { text: pack.ttsPanel.title }));
+  const controls = createElement('div', { className: 'tts-controls' });
+  const playButton = createElement('button', { text: state.ttsState.playing ? pack.ttsPanel.pause : pack.ttsPanel.play });
+  playButton.type = 'button';
+  playButton.addEventListener('click', () => {
+    state.ttsState.playing = !state.ttsState.playing;
+    renderApp();
+  });
+  const speedSelect = createElement('select');
+  [0.5, 1, 1.25, 1.5, 2, 3].forEach((value) => {
+    const option = createElement('option', { text: `${value}×` });
+    option.value = value;
+    if (state.ttsState.speed === value) {
+      option.selected = true;
+    }
+    speedSelect.appendChild(option);
+  });
+  speedSelect.addEventListener('change', (event) => {
+    state.ttsState.speed = Number(event.target.value);
+  });
+
+  const voiceSelect = createElement('select');
+  [
+    { key: 'female', label: pack.ttsPanel.female },
+    { key: 'male', label: pack.ttsPanel.male },
+    { key: 'neutral', label: pack.ttsPanel.neutral }
+  ].forEach((option) => {
+    const node = createElement('option', { text: option.label });
+    node.value = option.key;
+    if (state.ttsState.voice === option.key) {
+      node.selected = true;
+    }
+    voiceSelect.appendChild(node);
+  });
+  voiceSelect.addEventListener('change', (event) => {
+    state.ttsState.voice = event.target.value;
+  });
+
+  const highlightToggle = createElement('label', { className: 'highlight-toggle' });
+  const highlightInput = createElement('input', { attributes: { type: 'checkbox' } });
+  highlightInput.checked = state.ttsState.highlight;
+  highlightInput.addEventListener('change', (event) => {
+    state.ttsState.highlight = event.target.checked;
+    renderApp();
+  });
+  highlightToggle.appendChild(highlightInput);
+  highlightToggle.appendChild(createElement('span', { text: pack.ttsPanel.highlight }));
+
+  controls.appendChild(playButton);
+  controls.appendChild(createElement('span', { text: `${pack.ttsPanel.speed}` }));
+  controls.appendChild(speedSelect);
+  controls.appendChild(createElement('span', { text: `${pack.ttsPanel.voice}` }));
+  controls.appendChild(voiceSelect);
+  controls.appendChild(highlightToggle);
+  container.appendChild(controls);
+
+  if (!book.tts) {
+    container.appendChild(
+      createElement('p', {
+        className: 'tts-warning',
+        text: state.locale === 'zh' ? '该格式暂不支持朗读' : 'TTS is not available for this format.'
+      })
+    );
+  }
+  return container;
+}
+
+function renderExportPanel(pack, bookIds) {
+  const container = createElement('div', { className: 'export-panel' });
+  container.appendChild(createElement('h4', { text: pack.exportPanel.title }));
+  const destinationInput = createElement('input', {
+    attributes: { type: 'text', value: state.exportState.destination }
+  });
+  destinationInput.addEventListener('change', (event) => {
+    state.exportState.destination = event.target.value;
+  });
+  const metadataToggle = createElement('label', { className: 'highlight-toggle' });
+  const metadataInput = createElement('input', { attributes: { type: 'checkbox' } });
+  metadataInput.checked = state.exportState.includeMetadata;
+  metadataInput.addEventListener('change', (event) => {
+    state.exportState.includeMetadata = event.target.checked;
+  });
+  metadataToggle.appendChild(metadataInput);
+  metadataToggle.appendChild(createElement('span', { text: pack.exportPanel.metadataPage }));
+
+  const startButton = createElement('button', { text: pack.exportPanel.start });
+  startButton.type = 'button';
+  startButton.addEventListener('click', () => startExport(bookIds));
+
+  const progress = createElement('div', { className: 'progress-track' });
+  const fill = createElement('div', {
+    className: 'progress-fill',
+    attributes: { style: `width: ${state.exportState.progress}%` }
+  });
+  progress.appendChild(fill);
+
+  const statusText =
+    state.exportState.status === 'completed'
+      ? pack.exportPanel.success
+      : state.exportState.status === 'running'
+        ? `${pack.exportPanel.progressLabel}: ${state.exportState.progress}%`
+        : '';
+
+  container.appendChild(createElement('label', { text: pack.exportPanel.destination }));
+  container.appendChild(destinationInput);
+  container.appendChild(metadataToggle);
+  container.appendChild(startButton);
+  container.appendChild(progress);
+  if (statusText) {
+    container.appendChild(createElement('p', { className: 'export-status', text: statusText }));
+  }
+  return container;
+}
+function ensureAiSession(collectionId) {
+  if (!state.aiSessions[collectionId]) {
+    const display = getCollectionDisplay(collectionId);
+    state.aiSessions[collectionId] = {
+      messages: [
+        {
+          role: 'assistant',
+          content:
+            state.locale === 'zh'
+              ? `欢迎来到「${display?.title || ''}」研究助手。我可以基于本地图书文本提供摘要、提问和引用。`
+              : `Welcome to the ${display?.title || ''} research assistant. Ask about themes, insights, or request citations.`,
+          citations: []
+        }
+      ],
+      loading: false
+    };
+  }
+  return state.aiSessions[collectionId];
+}
+
+function sendAiMessage(collectionId, prompt) {
+  if (!prompt.trim()) {
+    return;
+  }
+  const session = ensureAiSession(collectionId);
+  session.messages.push({ role: 'user', content: prompt, citations: [] });
+  session.loading = true;
+  renderApp();
+  setTimeout(() => {
+    const books = getBooks(collectionId);
+    const cited = books[Math.floor(Math.random() * books.length)];
+    session.messages.push({
+      role: 'assistant',
+      content:
+        state.locale === 'zh'
+          ? `根据《${cited.title}》的第 ${Math.ceil(Math.random() * cited.pages)} 页，建议关注其关于 ${getClassificationLabel(
+              cited.classification
+            )} 的讨论，以支持你的问题。`
+          : `Drawing on page ${Math.ceil(Math.random() * cited.pages)} of “${cited.title}”, consider the section on ${getClassificationLabel(
+              cited.classification
+            )} to deepen this line of inquiry.`,
+      citations: [{ bookId: cited.id, page: Math.ceil(Math.random() * cited.pages) }]
+    });
+    session.loading = false;
+    renderApp();
+  }, 650);
+}
+
+function renderAiPanel(pack) {
+  const collectionId = state.selectedCollectionId;
+  if (!collectionId) {
+    return null;
+  }
+  const session = ensureAiSession(collectionId);
+  const container = createElement('section', { className: 'ai-panel' });
+  container.appendChild(createElement('h3', { text: pack.aiPanel.title }));
+  container.appendChild(createElement('p', { className: 'ai-notice', text: pack.aiPanel.groundingNotice }));
+
+  const transcript = createElement('div', { className: 'ai-transcript' });
+  session.messages.forEach((message) => {
+    const bubble = createElement('div', { className: `ai-bubble ${message.role}` });
+    bubble.appendChild(createElement('p', { text: message.content }));
+    if (message.citations && message.citations.length) {
+      const citationList = createElement('ul', { className: 'ai-citations' });
+      message.citations.forEach((citation) => {
+        const book = findBookById(citation.bookId);
+        citationList.appendChild(
+          createElement('li', {
+            text: `${pack.aiPanel.citationLabel}: ${book?.title || ''} · ${state.locale === 'zh' ? '第' : 'p.'} ${citation.page}`
+          })
+        );
+      });
+      bubble.appendChild(citationList);
+    }
+    transcript.appendChild(bubble);
+  });
+  if (session.loading) {
+    transcript.appendChild(
+      createElement('div', {
+        className: 'ai-bubble assistant loading',
+        text: state.locale === 'zh' ? '正在检索向量索引…' : 'Retrieving collection index…'
+      })
+    );
+  }
+  container.appendChild(transcript);
+
+  const composer = createElement('div', { className: 'ai-composer' });
+  const input = createElement('textarea', {
+    attributes: { placeholder: pack.aiPanel.placeholder, rows: 2 }
+  });
+  const sendButton = createElement('button', { text: pack.aiPanel.send });
+  sendButton.type = 'button';
+  sendButton.addEventListener('click', () => {
+    sendAiMessage(collectionId, input.value);
+    input.value = '';
+  });
+  composer.appendChild(input);
+  composer.appendChild(sendButton);
+
+  const newChat = createElement('button', { className: 'ghost-button', text: pack.aiPanel.newChat });
+  newChat.type = 'button';
+  newChat.addEventListener('click', () => {
+    state.aiSessions[collectionId] = undefined;
+    ensureAiSession(collectionId);
+    renderApp();
+  });
+
+  container.appendChild(composer);
+  container.appendChild(newChat);
+  return container;
+}
+function renderSettingsOverlay(pack) {
+  const overlay = createElement('div', { className: 'modal-overlay' });
+  const panel = createElement('div', { className: 'modal-panel' });
+  panel.appendChild(createElement('h3', { text: pack.settings.title }));
+
+  const metadataGroup = createElement('div', { className: 'settings-group' });
+  metadataGroup.appendChild(createElement('h4', { text: pack.settings.tabs[0] }));
+  const metadataSources = createElement('input', {
+    attributes: { type: 'text', value: state.settings.metadataSources }
+  });
+  metadataSources.addEventListener('change', (event) => {
+    state.settings.metadataSources = event.target.value;
+  });
+  const apiKey = createElement('input', {
+    attributes: { type: 'text', value: state.settings.apiKey, placeholder: pack.settings.apiKey }
+  });
+  apiKey.addEventListener('change', (event) => {
+    state.settings.apiKey = event.target.value;
+  });
+  const rateLimit = createElement('input', {
+    attributes: { type: 'number', min: 1, value: state.settings.rateLimit }
+  });
+  rateLimit.addEventListener('change', (event) => {
+    state.settings.rateLimit = Number(event.target.value);
+  });
+  const proxy = createElement('input', {
+    attributes: { type: 'text', value: state.settings.proxy, placeholder: 'https://proxy.local:7890' }
+  });
+  proxy.addEventListener('change', (event) => {
+    state.settings.proxy = event.target.value;
+  });
+
+  metadataGroup.appendChild(createElement('label', { text: pack.settings.metadataSources }));
+  metadataGroup.appendChild(metadataSources);
+  metadataGroup.appendChild(createElement('label', { text: pack.settings.apiKey }));
+  metadataGroup.appendChild(apiKey);
+  metadataGroup.appendChild(createElement('label', { text: pack.settings.rateLimit }));
+  metadataGroup.appendChild(rateLimit);
+  metadataGroup.appendChild(createElement('label', { text: pack.settings.proxy }));
+  metadataGroup.appendChild(proxy);
+
+  const storageGroup = createElement('div', { className: 'settings-group' });
+  storageGroup.appendChild(createElement('h4', { text: pack.settings.tabs[1] }));
+  const cachePath = createElement('input', {
+    attributes: { type: 'text', value: state.settings.cachePath }
+  });
+  cachePath.addEventListener('change', (event) => {
+    state.settings.cachePath = event.target.value;
+  });
+  const previewPath = createElement('input', {
+    attributes: { type: 'text', value: state.settings.previewPath }
+  });
+  previewPath.addEventListener('change', (event) => {
+    state.settings.previewPath = event.target.value;
+  });
+  const embeddingsPath = createElement('input', {
+    attributes: { type: 'text', value: state.settings.embeddingsPath }
+  });
+  embeddingsPath.addEventListener('change', (event) => {
+    state.settings.embeddingsPath = event.target.value;
+  });
+  storageGroup.appendChild(createElement('label', { text: pack.settings.cachePath }));
+  storageGroup.appendChild(cachePath);
+  storageGroup.appendChild(createElement('label', { text: pack.settings.previewPath }));
+  storageGroup.appendChild(previewPath);
+  storageGroup.appendChild(createElement('label', { text: pack.settings.embeddingsPath }));
+  storageGroup.appendChild(embeddingsPath);
+
+  const readerGroup = createElement('div', { className: 'settings-group' });
+  readerGroup.appendChild(createElement('h4', { text: pack.settings.tabs[2] }));
+  const paginationInput = createElement('input', {
+    attributes: { type: 'number', min: 10, max: 500, value: state.settings.paginationDefault }
+  });
+  paginationInput.addEventListener('change', (event) => {
+    state.settings.paginationDefault = Number(event.target.value);
+  });
+  const themeSelect = createElement('select');
+  ['system', 'light', 'dark'].forEach((value) => {
+    const option = createElement('option', { text: value });
+    option.value = value;
+    if (state.settings.theme === value) {
+      option.selected = true;
+    }
+    themeSelect.appendChild(option);
+  });
+  themeSelect.addEventListener('change', (event) => {
+    state.settings.theme = event.target.value;
+  });
+  const analyticsToggle = createElement('label', { className: 'highlight-toggle' });
+  const analyticsInput = createElement('input', { attributes: { type: 'checkbox' } });
+  analyticsInput.checked = state.settings.analytics;
+  analyticsInput.addEventListener('change', (event) => {
+    state.settings.analytics = event.target.checked;
+  });
+  analyticsToggle.appendChild(analyticsInput);
+  analyticsToggle.appendChild(createElement('span', { text: pack.settings.analytics }));
+  const offlineToggle = createElement('label', { className: 'highlight-toggle' });
+  const offlineInput = createElement('input', { attributes: { type: 'checkbox' } });
+  offlineInput.checked = state.settings.offline;
+  offlineInput.addEventListener('change', (event) => {
+    state.settings.offline = event.target.checked;
+  });
+  offlineToggle.appendChild(offlineInput);
+  offlineToggle.appendChild(createElement('span', { text: pack.settings.offline }));
+
+  readerGroup.appendChild(createElement('label', { text: pack.settings.paginationDefault }));
+  readerGroup.appendChild(paginationInput);
+  readerGroup.appendChild(createElement('label', { text: pack.settings.theme }));
+  readerGroup.appendChild(themeSelect);
+  readerGroup.appendChild(analyticsToggle);
+  readerGroup.appendChild(offlineToggle);
+
+  const actions = createElement('div', { className: 'modal-actions' });
+  const closeButton = createElement('button', { className: 'ghost-button', text: pack.wizard.cancel });
+  closeButton.type = 'button';
+  closeButton.addEventListener('click', () => {
+    state.settingsOpen = false;
+    renderApp();
+  });
+  const saveButton = createElement('button', { text: pack.settings.save });
+  saveButton.type = 'button';
+  saveButton.addEventListener('click', () => {
+    state.settingsOpen = false;
+    showToast(pack.settings.saved);
+    renderApp();
+  });
+  actions.appendChild(closeButton);
+  actions.appendChild(saveButton);
+
+  panel.appendChild(metadataGroup);
+  panel.appendChild(storageGroup);
+  panel.appendChild(readerGroup);
+  panel.appendChild(actions);
+  overlay.appendChild(panel);
+  return overlay;
+}
+
+function getJobTypeLabel(type) {
+  if (type === 'scan') {
+    return state.locale === 'zh' ? '文件扫描' : 'Filesystem scan';
+  }
+  if (type === 'enrichment') {
+    return state.locale === 'zh' ? '元数据刷新' : 'Metadata refresh';
+  }
+  if (type === 'export') {
+    return state.locale === 'zh' ? '导出 PDF' : 'Export to PDF';
+  }
+  return type;
+}
+
+function renderMonitorOverlay(pack) {
+  const overlay = createElement('div', { className: 'modal-overlay' });
+  const panel = createElement('div', { className: 'modal-panel wide' });
+  panel.appendChild(createElement('h3', { text: pack.monitor.title }));
+  const closeButton = createElement('button', { className: 'ghost-button', text: pack.wizard.cancel });
+  closeButton.type = 'button';
+  closeButton.addEventListener('click', () => {
+    state.monitorOpen = false;
+    renderApp();
+  });
+  panel.appendChild(closeButton);
+
+  if (!state.jobs.length) {
+    panel.appendChild(createElement('p', { className: 'empty-state', text: pack.monitor.empty }));
+  } else {
+    const table = createElement('table', { className: 'book-table job-table' });
+    const thead = createElement('thead');
+    const headerRow = createElement('tr');
+    pack.monitor.tableHeaders.forEach((label) => {
+      headerRow.appendChild(createElement('th', { text: label }));
+    });
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+    const tbody = createElement('tbody');
+    state.jobs.forEach((job) => {
+      const row = createElement('tr');
+      row.appendChild(createElement('td', { text: getJobTypeLabel(job.type) }));
+      row.appendChild(createElement('td', { text: getCollectionDisplay(job.collectionId)?.title || '' }));
+      const progressCell = createElement('td');
+      progressCell.appendChild(
+        createElement('div', {
+          className: 'progress-track',
+          children: [
+            createElement('div', {
+              className: 'progress-fill',
+              attributes: { style: `width: ${job.progress}%` }
+            })
+          ]
+        })
+      );
+      progressCell.appendChild(createElement('span', { text: `${job.progress}%` }));
+      row.appendChild(progressCell);
+      row.appendChild(createElement('td', { text: pack.monitor.statuses[job.status] || job.status }));
+      row.appendChild(createElement('td', { text: formatDate(job.updatedAt) }));
+      tbody.appendChild(row);
+    });
+    table.appendChild(tbody);
+    panel.appendChild(table);
+  }
+  overlay.appendChild(panel);
+  return overlay;
+}
+
+function renderWizardOverlay(pack) {
+  if (!state.showWizard) {
+    return null;
+  }
+  const overlay = createElement('div', { className: 'modal-overlay' });
+  const panel = createElement('div', { className: 'modal-panel wizard' });
+  panel.appendChild(createElement('h3', { text: pack.wizard.title }));
+  const stepInfo = pack.wizard.steps[state.wizardStep];
+  panel.appendChild(createElement('h4', { text: stepInfo.title }));
+  panel.appendChild(createElement('p', { className: 'wizard-helper', text: stepInfo.helper }));
+
+  if (state.wizardErrors.length) {
+    const errorList = createElement('ul', { className: 'wizard-errors' });
+    state.wizardErrors.forEach((error) => {
+      errorList.appendChild(createElement('li', { text: error }));
+    });
+    panel.appendChild(errorList);
+  }
+
+  if (state.wizardStep === 0) {
+    const pathList = createElement('div', { className: 'path-list' });
+    directoryOptions.forEach((option) => {
+      const label = createElement('label', { className: 'highlight-toggle' });
+      const input = createElement('input', { attributes: { type: 'checkbox' } });
+      input.checked = state.wizardData.paths.includes(option.path);
+      input.addEventListener('change', (event) => {
+        if (event.target.checked) {
+          if (!state.wizardData.paths.includes(option.path)) {
+            state.wizardData.paths.push(option.path);
+          }
+        } else {
+          state.wizardData.paths = state.wizardData.paths.filter((path) => path !== option.path);
+        }
+      });
+      label.appendChild(input);
+      label.appendChild(
+        createElement('span', {
+          html: `<strong>${option.path}</strong><br /><small>${formatDate(option.lastIndexed)} · ${option.helper}</small>`
+        })
+      );
+      pathList.appendChild(label);
+    });
+    if (!state.wizardData.paths.length) {
+      pathList.appendChild(createElement('p', { className: 'wizard-helper', text: pack.wizard.emptyPathHelper }));
+    }
+    const customInput = createElement('input', {
+      attributes: { type: 'text', placeholder: pack.wizard.directoryPlaceholder }
+    });
+    const addButton = createElement('button', { className: 'ghost-button', text: pack.wizard.addPathButton });
+    addButton.type = 'button';
+    addButton.addEventListener('click', () => {
+      if (customInput.value.trim() && !state.wizardData.paths.includes(customInput.value.trim())) {
+        state.wizardData.paths.push(customInput.value.trim());
+        customInput.value = '';
+        renderApp();
+      }
+    });
+    panel.appendChild(pathList);
+    panel.appendChild(customInput);
+    panel.appendChild(addButton);
+  } else if (state.wizardStep === 1) {
+    const nameInput = createElement('input', { attributes: { type: 'text', value: state.wizardData.name } });
+    nameInput.addEventListener('input', (event) => {
+      state.wizardData.name = event.target.value;
+    });
+    const descriptionInput = createElement('textarea', {
+      attributes: { rows: 3, value: state.wizardData.description }
+    });
+    descriptionInput.addEventListener('input', (event) => {
+      state.wizardData.description = event.target.value;
+    });
+    panel.appendChild(createElement('label', { text: pack.wizard.nameLabel }));
+    panel.appendChild(nameInput);
+    panel.appendChild(createElement('label', { text: pack.wizard.descriptionLabel }));
+    panel.appendChild(descriptionInput);
+  } else if (state.wizardStep === 2) {
+    const coverInput = createElement('input', { attributes: { type: 'file', accept: 'image/png,image/jpeg,image/webp' } });
+    coverInput.addEventListener('change', (event) => {
+      const file = event.target.files?.[0];
+      if (file) {
+        state.wizardData.coverFile = file;
+        state.wizardData.coverName = file.name;
+      }
+    });
+    panel.appendChild(createElement('label', { text: pack.wizard.coverLabel }));
+    panel.appendChild(coverInput);
+    if (state.wizardData.coverName) {
+      panel.appendChild(createElement('p', { text: state.wizardData.coverName }));
+    } else {
+      panel.appendChild(createElement('p', { className: 'wizard-helper', text: pack.wizard.dropHint }));
+    }
+  }
+
+  const actions = createElement('div', { className: 'modal-actions' });
+  const cancelButton = createElement('button', { className: 'ghost-button', text: pack.wizard.cancel });
+  cancelButton.type = 'button';
+  cancelButton.addEventListener('click', closeWizard);
+  const backButton = createElement('button', { className: 'ghost-button', text: pack.wizard.back });
+  backButton.type = 'button';
+  backButton.disabled = state.wizardStep === 0;
+  backButton.addEventListener('click', () => {
+    if (state.wizardStep > 0) {
+      state.wizardStep -= 1;
+      state.wizardErrors = [];
+      renderApp();
+    }
+  });
+  const nextButton = createElement('button', {
+    text: state.wizardStep === 2 ? pack.wizard.finish : pack.wizard.next
+  });
+  nextButton.type = 'button';
+  nextButton.addEventListener('click', () => {
+    if (!validateWizardStep(state.wizardStep)) {
+      return;
+    }
+    if (state.wizardStep === 2) {
+      completeWizard();
+      return;
+    }
+    state.wizardStep += 1;
+    state.wizardErrors = [];
+    renderApp();
+  });
+  actions.appendChild(cancelButton);
+  actions.appendChild(backButton);
+  actions.appendChild(nextButton);
+  panel.appendChild(actions);
+  overlay.appendChild(panel);
+  return overlay;
+}
+
+function renderToast() {
+  if (!state.toast) {
+    return null;
+  }
+  return createElement('div', { className: 'toast', text: state.toast.message });
+}
 
 function renderApp() {
-  const pack = translations[currentLocale];
+  const pack = getPack();
   root.innerHTML = '';
   const appShell = createElement('div', { className: 'app-shell' });
   appShell.appendChild(renderTopBar(pack));
   appShell.appendChild(renderStats(pack));
   appShell.appendChild(renderCollections(pack));
+  if (state.selectedCollectionId) {
+    appShell.appendChild(renderCollectionDetail(pack));
+    const experienceGrid = createElement('div', { className: 'experience-grid' });
+    experienceGrid.appendChild(renderPreviewPanel(pack));
+    experienceGrid.appendChild(renderAiPanel(pack));
+    appShell.appendChild(experienceGrid);
+  }
   appShell.appendChild(renderRoadmap(pack));
   root.appendChild(appShell);
+
+  if (state.settingsOpen) {
+    root.appendChild(renderSettingsOverlay(pack));
+  }
+  if (state.monitorOpen) {
+    root.appendChild(renderMonitorOverlay(pack));
+  }
+  if (state.showWizard) {
+    const overlay = renderWizardOverlay(pack);
+    if (overlay) {
+      root.appendChild(overlay);
+    }
+  }
+  const toast = renderToast();
+  if (toast) {
+    root.appendChild(toast);
+  }
 }
 
-function switchLocale(locale) {
-  if (locale === currentLocale) {
-    return;
-  }
-  if (!translations[locale]) {
-    console.warn(`Locale ${locale} is not available.`);
-    return;
-  }
-  currentLocale = locale;
+document.addEventListener('DOMContentLoaded', () => {
   renderApp();
-}
-
-document.addEventListener('DOMContentLoaded', renderApp);
+});

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -171,3 +171,533 @@ body {
     grid-template-columns: 1fr;
   }
 }
+
+.hero-group {
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hero-group h1 {
+  margin: 0;
+  font-size: 2.2rem;
+  color: #f8fafc;
+}
+
+.hero-group p {
+  margin: 0;
+  color: #cbd5f5;
+  font-size: 1rem;
+}
+
+.action-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.pill-button {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.6);
+  color: #e2e8f0;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.pill-button.active,
+.pill-button:hover {
+  background: linear-gradient(135deg, #38bdf8 0%, #6366f1 100%);
+  color: #0f172a;
+  border-color: transparent;
+}
+
+.detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: rgba(15, 23, 42, 0.6);
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.detail-section h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #f8fafc;
+}
+
+.detail-subtitle {
+  margin: 0;
+  color: #94a3b8;
+}
+
+.detail-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.ghost-button {
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: transparent;
+  color: #e2e8f0;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.ghost-button:hover {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.filters-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.search-input {
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.7);
+  color: #f8fafc;
+}
+
+.filter-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, auto));
+  align-items: center;
+  gap: 12px;
+}
+
+.filter-select,
+.year-filter input {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.7);
+  color: #e2e8f0;
+}
+
+.year-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.year-inputs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #94a3b8;
+}
+
+.layout-toggle {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  overflow: hidden;
+}
+
+.layout-toggle button {
+  padding: 10px 18px;
+  background: transparent;
+  border: none;
+  color: #cbd5f5;
+  cursor: pointer;
+}
+
+.layout-toggle button.active {
+  background: linear-gradient(135deg, #6366f1 0%, #38bdf8 100%);
+  color: #0f172a;
+}
+
+.book-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 18px;
+}
+
+.book-card {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.book-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(96, 165, 250, 0.6);
+}
+
+.book-card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.book-card-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #f8fafc;
+}
+
+.book-meta {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.book-summary {
+  margin: 0;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.progress-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: #38bdf8;
+}
+
+.progress-track {
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(135deg, #38bdf8 0%, #6366f1 100%);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.book-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.book-table th,
+.book-table td {
+  padding: 14px;
+  text-align: left;
+  color: #e2e8f0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.book-table tbody tr:hover {
+  background: rgba(96, 165, 250, 0.08);
+}
+
+.table-sort {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.table-sort.sort-asc::after,
+.table-sort.sort-desc::after {
+  content: '';
+  border: 6px solid transparent;
+}
+
+.table-sort.sort-asc::after {
+  border-bottom-color: #38bdf8;
+}
+
+.table-sort.sort-desc::after {
+  border-top-color: #38bdf8;
+}
+
+.pagination-controls,
+.bulk-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  color: #94a3b8;
+}
+
+.bulk-actions button {
+  min-width: 140px;
+}
+
+.preview-panel {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.preview-meta {
+  margin: 0;
+  color: #94a3b8;
+}
+
+.preview-controls {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.preview-page {
+  margin: 0;
+  color: #cbd5f5;
+}
+
+.preview-content {
+  padding: 16px;
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  transform-origin: top left;
+  line-height: 1.6;
+}
+
+.preview-content.tts-active {
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.4);
+}
+
+.tts-panel,
+.export-panel {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tts-panel h4,
+.export-panel h4 {
+  margin: 0;
+  color: #f8fafc;
+}
+
+.tts-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.tts-warning {
+  margin: 0;
+  color: #facc15;
+}
+
+.highlight-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #cbd5f5;
+}
+
+.export-status {
+  margin: 0;
+  color: #38bdf8;
+}
+
+.ai-panel {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ai-notice {
+  margin: 0;
+  color: #94a3b8;
+}
+
+.ai-transcript {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.ai-bubble {
+  padding: 12px 16px;
+  border-radius: 16px;
+  line-height: 1.5;
+}
+
+.ai-bubble.user {
+  background: rgba(59, 130, 246, 0.2);
+  align-self: flex-end;
+}
+
+.ai-bubble.assistant {
+  background: rgba(148, 163, 184, 0.15);
+  align-self: flex-start;
+}
+
+.ai-bubble.loading {
+  font-style: italic;
+  color: #94a3b8;
+}
+
+.ai-citations {
+  margin: 8px 0 0 0;
+  padding-left: 16px;
+  color: #94a3b8;
+}
+
+.ai-composer {
+  display: flex;
+  gap: 12px;
+}
+
+.ai-composer textarea {
+  flex: 1;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.7);
+  color: #f8fafc;
+  padding: 12px;
+}
+
+.experience-grid {
+  display: grid;
+  grid-template-columns: 2fr 1.2fr;
+  gap: 20px;
+}
+
+@media (max-width: 1024px) {
+  .experience-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+  padding: 24px;
+}
+
+.modal-panel {
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 24px;
+  max-width: 720px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.6);
+}
+
+.modal-panel.wide {
+  max-width: 900px;
+}
+
+.modal-panel.wizard {
+  max-width: 640px;
+}
+
+.settings-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-group h4 {
+  margin: 0;
+  color: #38bdf8;
+}
+
+.settings-group input,
+.settings-group select,
+.settings-group textarea {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.7);
+  color: #f8fafc;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.path-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.wizard-helper {
+  color: #94a3b8;
+  margin: 0;
+}
+
+.wizard-errors {
+  margin: 0;
+  padding-left: 18px;
+  color: #f87171;
+}
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 12px 18px;
+  border-radius: 12px;
+  color: #f8fafc;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.5);
+  z-index: 30;
+}
+
+.job-table td:nth-child(3) {
+  min-width: 160px;
+}


### PR DESCRIPTION
## Summary
- expand localisation packs with wizard, dashboard, reader, AI, and settings copy
- implement interactive renderer covering collection management, previews, jobs, export, TTS, AI chat, and preferences
- add styling for wizard, detail views, preview controls, and overlays to match the functional spec

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4dd70e4988320896f4b620b2117eb