### PR TITLE
Update README with build and packaging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,70 @@ See [`docs/functional_spec.md`](docs/functional_spec.md) for the detailed functi
 
 ## Development Setup / 开发环境准备
 
-The UI blueprint now ships as a static bundle with no external npm dependencies so it can be explored completely offline.
+### 1. Install dependencies / 安装依赖
 
-1. Install dependencies 安装依赖（离线环境无需下载任何包）：
-   ```bash
-   npm install
-   ```
-2. Start the bilingual preview server 启动中英文预览服务：
-   ```bash
-   npm run dev
-   ```
-   The command launches a lightweight Node.js static server on [http://localhost:4173](http://localhost:4173).
+```bash
+npm install
+```
 
-3. Build static assets 构建静态资源：
-   ```bash
-   npm run build
-   ```
-   The compiled files are copied into the `dist/` folder for sharing or packaging.
+This installs Electron and the local build scripts used throughout development.
+
+### 2. Run the Electron app in development / 启动开发模式的 Electron 应用
+
+```bash
+npm run dev
+```
+
+This command launches the Electron main process, loads the renderer bundle from `src/renderer`, and opens the application window locally. 在开发模式下运行 Electron 主进程，并从 `src/renderer` 加载前端界面。
+
+### 3. Build static assets / 构建静态资源
+
+```bash
+npm run build
+```
+
+The script copies the renderer assets into the `dist/` directory. 该脚本会将前端静态资源复制到 `dist/` 目录，为后续打包做准备。
+
+## Packaging for Release / 发布打包
+
+The project uses the plain Electron runtime, so packaging relies on [`electron-packager`](https://github.com/electron/electron-packager). You can invoke it on-demand with `npx` without permanently adding a dependency. 项目默认使用 Electron 运行时，可以直接通过 `npx electron-packager` 进行跨平台打包。
+
+Before packaging, ensure the static assets are up to date:
+
+```bash
+npm run build
+```
+
+Then run one of the following commands depending on your target platform. `--overwrite` ensures old artifacts are replaced, and `--out release` places the bundles inside the `release/` folder.
+
+### macOS (Intel & Apple Silicon) / macOS（Intel 与 Apple Silicon）
+
+```bash
+npx electron-packager . "Local Bookshelf" \
+  --platform=darwin \
+  --arch=x64,arm64 \
+  --out=release \
+  --overwrite
+```
+
+### Windows
+
+```bash
+npx electron-packager . "Local Bookshelf" \
+  --platform=win32 \
+  --arch=ia32,x64 \
+  --out=release \
+  --overwrite
+```
+
+### Linux
+
+```bash
+npx electron-packager . "Local Bookshelf" \
+  --platform=linux \
+  --arch=x64,arm64 \
+  --out=release \
+  --overwrite
+```
+
+You can adjust the `--arch` values to match the required CPU architectures. 根据需要调整 `--arch` 参数即可生成目标架构的安装包。


### PR DESCRIPTION
## Summary
- document the steps to install dependencies, run the Electron app, and build static assets
- add cross-platform packaging instructions using `electron-packager`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5215b7d0c83209345c527aa1c8cf0