### PR TITLE
Simplify home header and improve collection wizard UX

### DIFF
--- a/src/renderer/data.js
+++ b/src/renderer/data.js
@@ -1,9 +1,8 @@
 export const translations = {
   en: {
     localeLabel: 'Language',
-    heroTitle: 'Local Bookshelf Experience Blueprint',
-    heroSubtitle:
-      'A bilingual reference UI that maps the Functional Specification into a tangible Electron + React layout skeleton.',
+    heroTitle: 'Local Library Management',
+    heroSubtitle: '',
     actionBar: {
       openSettings: 'Settings',
       toggleMonitor: 'Background Jobs'
@@ -21,7 +20,7 @@ export const translations = {
         id: 'new-collection',
         title: 'New Collection',
         description: 'Launch the creation wizard to add folders, metadata, and a custom cover.',
-        stats: 'Wizard · Drag & Drop Paths · Auto Scan',
+        stats: 'Wizard · Folder Picker · Auto Scan',
         actions: ['Start Wizard']
       },
       {
@@ -57,27 +56,21 @@ export const translations = {
     wizard: {
       title: 'New Collection Wizard',
       steps: [
-        { title: 'Choose Folders', helper: 'Drag and drop or pick directories that should be scanned.' },
+        { title: 'Choose Folders', helper: 'Pick directories for the collection using the folder picker.' },
         { title: 'Describe Collection', helper: 'Add a name and optional description for quick discovery.' },
         { title: 'Select Cover', helper: 'Upload a PNG, JPG, or WebP image that represents the shelf.' }
       ],
-      directoryPlaceholder: 'Add directories…',
-      browseForPath: 'Browse folders…',
-      addPathButton: 'Add Path',
+      browseForPath: 'Choose folders…',
       emptyPathHelper: 'No folders selected yet. Start with a handbook archive, downloads folder, or NAS share.',
       selectedTitle: 'Selected folders',
-      suggestionsTitle: 'Suggested locations',
-      useSuggested: 'Add this folder',
       editPath: 'Change…',
       removePath: 'Remove',
-      manualEntryHelper: 'Paste or type a folder path if you cannot browse to it.',
-      promptDirectory: 'Enter a folder path',
       duplicatePath: 'This folder has already been added.',
       nameLabel: 'Collection Name',
       descriptionLabel: 'Description',
       coverLabel: 'Cover Image',
       browseLabel: 'Browse…',
-      dropHint: 'Drop image here or use the file picker.',
+      dropHint: 'Use a 1280×720 image for best quality.',
       next: 'Next',
       back: 'Back',
       cancel: 'Cancel',
@@ -91,6 +84,34 @@ export const translations = {
       successTitle: 'Scan Started',
       successBody:
         'We are scanning your folders in the background. Progress appears in the job monitor and collection dashboard.'
+    },
+    scanOverlay: {
+      title: 'Scanning {name}',
+      subtitle: 'We are indexing your selected folders. Progress updates in real time.',
+      progressLabel: 'Progress',
+      statusLabel: 'Status',
+      status: {
+        queued: 'Waiting to start',
+        running: 'Scanning folders…',
+        completed: 'Scan complete'
+      },
+      pathsTitle: 'Folders being indexed',
+      logTitle: 'Activity log',
+      logs: {
+        empty: 'Waiting for the scanner to begin…',
+        queued: 'Job queued and pending worker availability.',
+        start: 'Started scanning {path}.',
+        discovery: 'Discovering folder structure and counting documents…',
+        metadata: 'Extracting metadata from supported formats…',
+        embeddings: 'Generating embeddings for AI answers…',
+        completed: 'Scan completed successfully.',
+        fallbackPath: 'selected folders'
+      },
+      buttons: {
+        home: 'Return home',
+        openCollection: 'Open collection'
+      },
+      fallbackName: 'collection'
     },
     monitor: {
       title: 'Background Jobs',
@@ -210,8 +231,8 @@ export const translations = {
   },
   zh: {
     localeLabel: '语言',
-    heroTitle: '本地书架体验蓝图',
-    heroSubtitle: '基于功能规格的双语界面雏形，展示 Electron + React 架构的核心布局。',
+    heroTitle: '本地图书管理',
+    heroSubtitle: '',
     actionBar: {
       openSettings: '系统设置',
       toggleMonitor: '后台任务'
@@ -229,7 +250,7 @@ export const translations = {
         id: 'new-collection',
         title: '创建新收藏集',
         description: '打开多步骤向导，添加文件夹、元数据与封面。',
-        stats: '向导 · 拖放路径 · 自动扫描',
+        stats: '向导 · 文件夹选择 · 自动扫描',
         actions: ['启动向导']
       },
       {
@@ -265,27 +286,21 @@ export const translations = {
     wizard: {
       title: '新建收藏集向导',
       steps: [
-        { title: '选择文件夹', helper: '拖放或选择需要扫描的目录。' },
+        { title: '选择文件夹', helper: '通过文件夹选择器挑选需要扫描的目录。' },
         { title: '填写信息', helper: '添加名称与可选描述，便于快速识别。' },
         { title: '设置封面', helper: '上传 PNG、JPG 或 WebP 图片作为封面。' }
       ],
-      directoryPlaceholder: '添加目录…',
       browseForPath: '选择文件夹…',
-      addPathButton: '新增路径',
       emptyPathHelper: '尚未选择文件夹，可以从手册档案、下载目录或 NAS 开始。',
       selectedTitle: '已选择的文件夹',
-      suggestionsTitle: '推荐位置',
-      useSuggested: '加入此文件夹',
       editPath: '更改…',
       removePath: '删除',
-      manualEntryHelper: '若无法浏览，可手动输入或粘贴路径。',
-      promptDirectory: '请输入文件夹路径',
       duplicatePath: '该文件夹已添加。',
       nameLabel: '收藏集名称',
       descriptionLabel: '简介',
       coverLabel: '封面图片',
       browseLabel: '浏览…',
-      dropHint: '拖拽图片至此或使用文件选择器。',
+      dropHint: '建议使用 1280×720 图片以获得最佳效果。',
       next: '下一步',
       back: '上一步',
       cancel: '取消',
@@ -298,6 +313,34 @@ export const translations = {
       },
       successTitle: '扫描已启动',
       successBody: '我们正在后台扫描您的文件夹，进度会显示在任务监视器与收藏集面板。'
+    },
+    scanOverlay: {
+      title: '正在扫描 {name}',
+      subtitle: '系统正在索引所选文件夹，进度信息实时更新。',
+      progressLabel: '进度',
+      statusLabel: '状态',
+      status: {
+        queued: '等待开始',
+        running: '扫描进行中…',
+        completed: '扫描完成'
+      },
+      pathsTitle: '扫描中的文件夹',
+      logTitle: '活动日志',
+      logs: {
+        empty: '正在等待扫描任务启动…',
+        queued: '任务已排队，等待可用的扫描资源。',
+        start: '开始扫描 {path}。',
+        discovery: '正在识别目录结构并统计文档数量…',
+        metadata: '正在解析文档元数据…',
+        embeddings: '正在生成 AI 所需的向量数据…',
+        completed: '扫描成功完成。',
+        fallbackPath: '所选文件夹'
+      },
+      buttons: {
+        home: '返回首页',
+        openCollection: '进入该收藏集'
+      },
+      fallbackName: '收藏集'
     },
     monitor: {
       title: '后台任务',

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -825,6 +825,255 @@ body {
   color: #0f172a;
 }
 
+.wizard-steps {
+  display: flex;
+  gap: 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.wizard-step {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.wizard-step.completed {
+  border-color: #c7d2fe;
+  background: #eef2ff;
+  color: #312e81;
+}
+
+.wizard-step.active {
+  border-color: #1d4ed8;
+  background: #e0e7ff;
+  color: #1e3a8a;
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.18);
+}
+
+.wizard-step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.wizard-step.completed .wizard-step-index {
+  background: #4c1d95;
+}
+
+.wizard-step.active .wizard-step-index {
+  background: #1e3a8a;
+}
+
+.wizard-step-title {
+  flex: 1;
+  font-size: 0.95rem;
+}
+
+.wizard-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wizard-field label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.wizard-input,
+.wizard-textarea,
+.wizard-file {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #0f172a;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.wizard-input:focus,
+.wizard-textarea:focus,
+.wizard-file:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+.wizard-textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.wizard-file::-webkit-file-upload-button {
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid #cbd5f5;
+  background: #e0e7ff;
+  color: #1d4ed8;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.wizard-file::file-selector-button {
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid #cbd5f5;
+  background: #e0e7ff;
+  color: #1d4ed8;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.primary-button {
+  padding: 10px 18px;
+  border-radius: 12px;
+  border: none;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button:hover {
+  background: #1e3a8a;
+  box-shadow: 0 10px 18px rgba(30, 58, 138, 0.25);
+}
+
+.primary-button:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.file-name-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.scan-panel {
+  max-width: 720px;
+}
+
+.scan-paths {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px dashed #cbd5f5;
+  border-radius: 16px;
+  padding: 16px;
+  background: #f8fafc;
+}
+
+.scan-paths-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #1d4ed8;
+}
+
+.scan-paths ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: #0f172a;
+  font-size: 0.95rem;
+  word-break: break-all;
+}
+
+.scan-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.scan-status-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.scan-progress-label,
+.scan-status-label {
+  font-size: 0.95rem;
+}
+
+.scan-status-label {
+  color: #475569;
+  font-weight: 500;
+}
+
+.scan-progress-track {
+  position: relative;
+  width: 100%;
+  height: 14px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  overflow: hidden;
+}
+
+.scan-progress-fill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #2563eb 0%, #4c1d95 100%);
+  transition: width 0.3s ease;
+}
+
+.scan-log {
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  background: #f8fafc;
+  padding: 16px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.scan-log ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.scan-log li {
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 0.88rem;
+  color: #334155;
+}
+
 .modal-actions {
   display: flex;
   justify-content: flex-end;
@@ -847,8 +1096,7 @@ body {
   color: #1d4ed8;
 }
 
-.path-row,
-.path-suggestion {
+.path-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -868,34 +1116,6 @@ body {
 .path-actions {
   display: flex;
   gap: 8px;
-}
-
-.path-manual-row {
-  display: flex;
-  gap: 8px;
-}
-
-.path-suggestions {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.path-suggestion-info {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  color: #1f2937;
-}
-
-.path-suggestion-info strong {
-  font-size: 0.95rem;
-  color: #0f172a;
-}
-
-.path-suggestion-info span {
-  font-size: 0.85rem;
-  color: #64748b;
 }
 
 .wizard-helper {


### PR DESCRIPTION
## Summary
- simplify the dashboard header and breadcrumbs by relying on localized titles and removing the roadmap section
- refresh the new collection wizard with a step indicator, styled fields, and folder selection via the picker only
- introduce a post-creation scan overlay with live progress/log updates and supporting styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e528307afc8320808fd94a075e61f7