### PR TITLE
feat: move data to sqlite and add system settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "MIT",
       "devDependencies": {
         "electron": "^28.2.0"
+      },
+      "dependencies": {
+        "better-sqlite3": "^8.5.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   },
   "devDependencies": {
     "electron": "^28.2.0"
+  },
+  "dependencies": {
+    "better-sqlite3": "^8.5.2"
   }
 }

--- a/src/main/database.js
+++ b/src/main/database.js
@@ -1,0 +1,167 @@
+const path = require('path');
+const fs = require('fs');
+const Database = require('better-sqlite3');
+const { app } = require('electron');
+
+const seeds = require('./seed-data');
+
+let dbInstance = null;
+
+function getDatabasePath() {
+  return path.join(app.getPath('userData'), 'local-bookshelf.db');
+}
+
+function getDatabase() {
+  if (dbInstance) {
+    return dbInstance;
+  }
+  const databasePath = getDatabasePath();
+  dbInstance = new Database(databasePath);
+  dbInstance.pragma('journal_mode = WAL');
+  return dbInstance;
+}
+
+function ensureTables(database) {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS translations (
+      locale TEXT PRIMARY KEY,
+      payload TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS app_state (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      payload TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `);
+}
+
+function populateStaticData(database) {
+  const insertTranslation = database.prepare(
+    'INSERT OR REPLACE INTO translations (locale, payload) VALUES (?, ?)' 
+  );
+  Object.entries(seeds.translations).forEach(([locale, payload]) => {
+    insertTranslation.run(locale, JSON.stringify(payload));
+  });
+
+  const metaSeeds = {
+    supportedCoverTypes: seeds.supportedCoverTypes,
+    classificationCatalog: seeds.classificationCatalog,
+    formatCatalog: seeds.formatCatalog,
+    statEmojiMap: seeds.statEmojiMap,
+    collectionEmojiMap: seeds.collectionEmojiMap,
+    classificationEmojiMap: seeds.classificationEmojiMap,
+    enrichmentLabels: seeds.enrichmentLabels,
+    classificationOptions: seeds.classificationOptions,
+    formatOptions: seeds.formatOptions,
+    directoryOptions: seeds.directoryOptions,
+    initialCollectionMetadata: seeds.initialCollectionMetadata,
+    initialCollectionBooks: seeds.initialCollectionBooks,
+    initialSettings: seeds.initialSettings,
+    defaultWizardData: seeds.defaultWizardData
+  };
+
+  const insertMeta = database.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)');
+  Object.entries(metaSeeds).forEach(([key, value]) => {
+    insertMeta.run(key, JSON.stringify(value));
+  });
+}
+
+function initializeDatabase() {
+  const database = getDatabase();
+  ensureTables(database);
+  database.transaction(() => {
+    populateStaticData(database);
+  })();
+}
+
+function loadState() {
+  const database = getDatabase();
+  const row = database.prepare('SELECT payload FROM app_state WHERE id = 1').get();
+  if (!row || !row.payload) {
+    return null;
+  }
+  try {
+    return JSON.parse(row.payload);
+  } catch (error) {
+    console.error('Failed to parse stored state', error);
+    return null;
+  }
+}
+
+function saveState(nextState) {
+  if (!nextState || typeof nextState !== 'object') {
+    return false;
+  }
+  const database = getDatabase();
+  const payload = JSON.stringify(nextState);
+  const timestamp = new Date().toISOString();
+  database
+    .prepare(
+      `INSERT INTO app_state (id, payload, updated_at)
+       VALUES (1, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET payload = excluded.payload, updated_at = excluded.updated_at`
+    )
+    .run(payload, timestamp);
+  return true;
+}
+
+function getBootstrapData() {
+  const database = getDatabase();
+  const translationRows = database.prepare('SELECT locale, payload FROM translations').all();
+  const translations = translationRows.reduce((acc, row) => {
+    try {
+      acc[row.locale] = JSON.parse(row.payload);
+    } catch (error) {
+      console.error('Failed to parse translation payload', row.locale, error);
+    }
+    return acc;
+  }, {});
+
+  const metaRows = database.prepare('SELECT key, value FROM meta').all();
+  const meta = metaRows.reduce((acc, row) => {
+    try {
+      acc[row.key] = JSON.parse(row.value);
+    } catch (error) {
+      console.error('Failed to parse meta payload', row.key, error);
+    }
+    return acc;
+  }, {});
+
+  return {
+    translations,
+    ...meta
+  };
+}
+
+function resetDatabase() {
+  const database = getDatabase();
+  database.transaction(() => {
+    database.exec('DELETE FROM app_state; DELETE FROM meta; DELETE FROM translations;');
+    populateStaticData(database);
+  })();
+}
+
+async function backupDatabase(targetPath) {
+  if (!targetPath) {
+    throw new Error('A target path is required for backup');
+  }
+  const database = getDatabase();
+  database.pragma('wal_checkpoint(FULL)');
+  database.pragma('wal_checkpoint(TRUNCATE)');
+  await fs.promises.mkdir(path.dirname(targetPath), { recursive: true });
+  await fs.promises.copyFile(getDatabasePath(), targetPath);
+}
+
+module.exports = {
+  initializeDatabase,
+  loadState,
+  saveState,
+  getBootstrapData,
+  resetDatabase,
+  backupDatabase,
+  getDatabasePath
+};

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -9,5 +9,14 @@ contextBridge.exposeInMainWorld('api', {
   },
   saveState(state) {
     return ipcRenderer.invoke('state:save', state);
+  },
+  bootstrap() {
+    return ipcRenderer.invoke('bootstrap:data');
+  },
+  initializeSystem() {
+    return ipcRenderer.invoke('system:initialize');
+  },
+  backupSystem(options) {
+    return ipcRenderer.invoke('system:backup', options);
   }
 });

--- a/src/main/seed-data.js
+++ b/src/main/seed-data.js
@@ -1,4 +1,4 @@
-export const translations = {
+const translations = {
   en: {
     localeLabel: 'Language',
     heroTitle: 'Local Library Management',
@@ -249,7 +249,19 @@ export const translations = {
       analytics: 'Usage analytics',
       offline: 'Offline mode',
       save: 'Save preferences',
-      saved: 'Preferences saved'
+      saved: 'Preferences saved',
+      system: {
+        title: 'System Maintenance',
+        helper: 'Initialize or back up the local database used by Local Bookshelf.',
+        initialize: 'Initialize system',
+        initializeConfirm: 'This will reset demo data and clear saved preferences. Continue?',
+        initializeSuccess: 'System initialization completed.',
+        initializeFailure: 'System initialization failed. Please try again.',
+        backup: 'Create backup',
+        backupSuccess: 'Backup saved to {path}',
+        backupFailure: 'Backup failed. Please try again.',
+        backupCanceled: 'Backup cancelled.'
+      }
     }
   },
   zh: {
@@ -501,7 +513,420 @@ export const translations = {
       analytics: '使用分析',
       offline: '离线模式',
       save: '保存设置',
-      saved: '设置已保存'
+      saved: '设置已保存',
+      system: {
+        title: '系统维护',
+        helper: '初始化或备份 Local Bookshelf 使用的本地数据库。',
+        initialize: '系统初始化',
+        initializeConfirm: '此操作将重置演示数据并清空保存的偏好，是否继续？',
+        initializeSuccess: '系统初始化完成。',
+        initializeFailure: '系统初始化失败，请重试。',
+        backup: '创建备份',
+        backupSuccess: '备份已保存至 {path}',
+        backupFailure: '备份失败，请重试。',
+        backupCanceled: '备份已取消。'
+      }
     }
   }
+};
+
+const supportedCoverTypes = ['image/png', 'image/jpeg', 'image/webp'];
+
+const classificationCatalog = {
+  X4: { en: 'Environmental Science Fundamentals', zh: '环境科学基础理论' },
+  X5: { en: 'Environmental Protection Management', zh: '环境保护管理' },
+  F2: { en: 'National Economic Management', zh: '国民经济管理' },
+  F49: { en: 'Energy Economics', zh: '能源经济' },
+  TU201: { en: 'Urban Planning Theory', zh: '城市规划理论' },
+  TB472: { en: 'Industrial Design', zh: '工业设计' },
+  'TB472.1': { en: 'Design Systems', zh: '设计系统' },
+  I2067: { en: 'Modern Chinese Fiction', zh: '现代小说' },
+  I227: { en: 'Poetry', zh: '诗歌' },
+  I267: { en: 'Essays & Reportage', zh: '散文·报告文学' }
+};
+
+const formatCatalog = {
+  pdf: { en: 'PDF', zh: 'PDF' },
+  epub: { en: 'EPUB', zh: 'EPUB' },
+  mobi: { en: 'MOBI', zh: 'MOBI' },
+  docx: { en: 'DOCX', zh: 'DOCX' },
+  txt: { en: 'Plain Text', zh: '纯文本' },
+  azw3: { en: 'AZW3', zh: 'AZW3' }
+};
+
+const statEmojiMap = {
+  collections: '🗂️',
+  books: '📚',
+  enrichment: '✨',
+  reading: '🎧'
+};
+
+const collectionEmojiMap = {
+  'new-collection': '🌟',
+  climate: '🌤️',
+  design: '🎨',
+  literature: '📖'
+};
+
+const classificationEmojiMap = {
+  X4: '🌊',
+  X5: '🏙️',
+  F2: '🏛️',
+  F49: '🔋',
+  TU201: '🏗️',
+  TB472: '🎨',
+  'TB472.1': '🧩',
+  I2067: '📖',
+  I227: '🎴',
+  I267: '📝'
+};
+
+const enrichmentLabels = {
+  complete: { en: 'Complete', zh: '已完成' },
+  inprogress: { en: 'In Progress', zh: '进行中' },
+  queued: { en: 'Queued', zh: '排队中' },
+  failed: { en: 'Failed', zh: '失败' }
+};
+
+const classificationOptions = ['X4', 'X5', 'F2', 'F49', 'TU201', 'TB472', 'TB472.1', 'I2067', 'I227', 'I267'];
+
+const formatOptions = ['pdf', 'epub', 'mobi', 'docx', 'txt', 'azw3'];
+
+const directoryOptions = [
+  {
+    id: 'handbooks',
+    path: '/Volumes/Research/Climate-Handbooks',
+    helper: 'Shared folder mounted from NAS',
+    lastIndexed: '2024-05-22T08:30:00Z'
+  },
+  {
+    id: 'ipcc',
+    path: '/Users/alex/Documents/IPCC-AR6',
+    helper: 'Downloaded assessment reports',
+    lastIndexed: '2024-05-20T10:02:00Z'
+  },
+  {
+    id: 'design-system',
+    path: 'D:/Libraries/Design-Systems',
+    helper: 'Sketches, PDFs, and pattern audits',
+    lastIndexed: '2024-04-28T14:10:00Z'
+  },
+  {
+    id: 'literature',
+    path: '/Volumes/Archive/Modern-Literature',
+    helper: 'Digitised literary anthologies',
+    lastIndexed: '2024-05-12T21:40:00Z'
+  }
+];
+
+const initialCollectionMetadata = {
+  climate: {
+    directories: ['/Volumes/Research/Climate-Handbooks', '/Users/alex/Documents/IPCC-AR6'],
+    lastScan: '2024-06-02T10:30:00Z',
+    pagination: 20,
+    aiEnabled: true
+  },
+  design: {
+    directories: ['D:/Libraries/Design-Systems', 'D:/Libraries/Accessibility-Guides'],
+    lastScan: '2024-05-28T18:20:00Z',
+    pagination: 12,
+    aiEnabled: true
+  },
+  literature: {
+    directories: ['/Volumes/Archive/Modern-Literature'],
+    lastScan: '2024-06-04T09:05:00Z',
+    pagination: 50,
+    aiEnabled: true
+  }
+};
+
+const initialCollectionBooks = {
+  climate: [
+    {
+      id: 'climate-1',
+      title: 'Resilient Cities 2040',
+      author: 'Mara Liang',
+      classification: 'X5',
+      publicationYear: 2024,
+      format: 'pdf',
+      sizeMB: 18.4,
+      dateAdded: '2024-05-18',
+      enrichment: 'complete',
+      pages: 328,
+      progress: { currentPage: 215 },
+      isbn: '978-0-12-864302-1',
+      summary: 'Action playbook for municipal adaptation projects across coastal regions.',
+      preview:
+        'Chapter 7 synthesises community-led design sprints with parametric flood models, outlining a replicable strategy for mid-sized cities.',
+      bookmarks: [64, 214],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'climate-2',
+      title: 'Policy Pathways for Net-Zero Provinces',
+      author: 'Dr. Felix Noor',
+      classification: 'F2',
+      publicationYear: 2022,
+      format: 'epub',
+      sizeMB: 6.2,
+      dateAdded: '2024-04-11',
+      enrichment: 'inprogress',
+      pages: 412,
+      progress: { currentPage: 87 },
+      isbn: '978-1-4028-9462-9',
+      summary: 'Comparative policy toolkit aligning provincial statutes with national carbon commitments.',
+      preview:
+        'Section 3.2 analyses differentiated responsibilities across heavy industry clusters with annotated case law.',
+      bookmarks: [23, 198],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'climate-3',
+      title: 'Ocean Heat Budget Explorer',
+      author: 'IPCC Working Group I',
+      classification: 'X4',
+      publicationYear: 2023,
+      format: 'pdf',
+      sizeMB: 52.7,
+      dateAdded: '2024-03-07',
+      enrichment: 'complete',
+      pages: 512,
+      progress: { currentPage: 132 },
+      isbn: '978-0-321-87777-4',
+      summary: 'High-resolution datasets and visualisations for ocean heat content analysis.',
+      preview:
+        'Appendix D introduces a methodology for downscaling CMIP6 outputs with GPU-accelerated interpolation.',
+      bookmarks: [112, 256, 401],
+      tts: false,
+      exportable: true
+    },
+    {
+      id: 'climate-4',
+      title: 'Distributed Energy Retrofit Manual',
+      author: 'Helena Ortiz',
+      classification: 'F49',
+      publicationYear: 2021,
+      format: 'docx',
+      sizeMB: 9.1,
+      dateAdded: '2024-02-19',
+      enrichment: 'queued',
+      pages: 226,
+      progress: { currentPage: 34 },
+      isbn: '978-0-452-29078-6',
+      summary: 'Practical guidance for retrofitting mid-rise buildings with hybrid solar microgrids.',
+      preview:
+        'Workbook templates cover financial modelling, procurement sequencing, and occupant engagement scripts.',
+      bookmarks: [48],
+      tts: true,
+      exportable: true
+    }
+  ],
+  design: [
+    {
+      id: 'design-1',
+      title: 'Multi-Platform Design Tokens',
+      author: 'Lina Osei',
+      classification: 'TB472.1',
+      publicationYear: 2023,
+      format: 'pdf',
+      sizeMB: 12.2,
+      dateAdded: '2024-05-01',
+      enrichment: 'complete',
+      pages: 280,
+      progress: { currentPage: 144 },
+      isbn: '978-0-07-352343-1',
+      summary: 'Unified token taxonomy bridging web, desktop, and native mobile design systems.',
+      preview:
+        'The alignment matrix maps each decision token to platform accessibility requirements with traceable histories.',
+      bookmarks: [56, 233],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'design-2',
+      title: 'Inclusive Motion Guidelines',
+      author: 'Yuko Nishimura',
+      classification: 'TB472',
+      publicationYear: 2020,
+      format: 'pdf',
+      sizeMB: 4.8,
+      dateAdded: '2024-04-16',
+      enrichment: 'complete',
+      pages: 164,
+      progress: { currentPage: 98 },
+      isbn: '978-0-12-549080-2',
+      summary: 'Framework for designing motion systems that respect vestibular comfort and localisation.',
+      preview:
+        'Case studies demonstrate velocity envelopes and offer CSS/SwiftUI code recipes to ship responsibly.',
+      bookmarks: [34, 88, 129],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'design-3',
+      title: 'Operational Playbook for DesignOps',
+      author: 'Carlos Mendes',
+      classification: 'TB472',
+      publicationYear: 2021,
+      format: 'epub',
+      sizeMB: 5.6,
+      dateAdded: '2024-03-08',
+      enrichment: 'inprogress',
+      pages: 312,
+      progress: { currentPage: 201 },
+      isbn: '978-0-7637-2026-6',
+      summary: 'Roadmap for scaling design systems governance with measurable service levels.',
+      preview:
+        'The service blueprint highlights intake triage, triads, and backlog analytics for distributed teams.',
+      bookmarks: [76, 240],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'design-4',
+      title: 'Accessibility Compliance Field Notes',
+      author: 'Priya Venkataraman',
+      classification: 'TB472',
+      publicationYear: 2019,
+      format: 'docx',
+      sizeMB: 3.4,
+      dateAdded: '2024-02-14',
+      enrichment: 'complete',
+      pages: 198,
+      progress: { currentPage: 45 },
+      isbn: '978-0-13-466535-4',
+      summary: 'Annotated checklist mapping WCAG 2.2 success criteria to practical inspection routines.',
+      preview:
+        'Field observations catalogue recurring defects and remediation scripts used by enterprise auditors.',
+      bookmarks: [18, 172],
+      tts: true,
+      exportable: true
+    }
+  ],
+  literature: [
+    {
+      id: 'literature-1',
+      title: 'Midnight Courtyard',
+      author: 'Han Yuerong',
+      classification: 'I2067',
+      publicationYear: 2018,
+      format: 'epub',
+      sizeMB: 2.3,
+      dateAdded: '2024-05-30',
+      enrichment: 'complete',
+      pages: 296,
+      progress: { currentPage: 186 },
+      isbn: '978-7-5321-6783-4',
+      summary: 'Interwoven narratives exploring urban solitude and resilience in Shanghai.',
+      preview:
+        'Chapter 12 juxtaposes architectural memories with present-day dialogues, inviting reflective annotation.',
+      bookmarks: [45, 132, 205],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'literature-2',
+      title: 'Letters to the South Wind',
+      author: 'Qiu Ansheng',
+      classification: 'I267',
+      publicationYear: 2020,
+      format: 'pdf',
+      sizeMB: 7.9,
+      dateAdded: '2024-04-22',
+      enrichment: 'complete',
+      pages: 224,
+      progress: { currentPage: 44 },
+      isbn: '978-7-5366-9860-2',
+      summary: 'Literary reportage blending climate narratives with personal field diaries.',
+      preview:
+        'Essays weave metaphors from typhoon tracking data and oral histories collected along the coast.',
+      bookmarks: [38, 110],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'literature-3',
+      title: 'Echoes on Lushan Trail',
+      author: 'Zhang Mingwei',
+      classification: 'I227',
+      publicationYear: 2015,
+      format: 'pdf',
+      sizeMB: 3.1,
+      dateAdded: '2024-03-19',
+      enrichment: 'inprogress',
+      pages: 168,
+      progress: { currentPage: 98 },
+      isbn: '978-7-5302-9342-7',
+      summary: 'Bilingual poetry sequence inspired by misty mornings in Jiangxi.',
+      preview:
+        'Bamboo stanza forms echo classical cadences while layering contemporary environmental imagery.',
+      bookmarks: [12, 97, 146],
+      tts: true,
+      exportable: true
+    },
+    {
+      id: 'literature-4',
+      title: 'Oral Histories of the Pearl Delta',
+      author: 'Luo Jia',
+      classification: 'I267',
+      publicationYear: 2017,
+      format: 'txt',
+      sizeMB: 1.1,
+      dateAdded: '2024-02-02',
+      enrichment: 'complete',
+      pages: 342,
+      progress: { currentPage: 276 },
+      isbn: '978-7-108-06618-2',
+      summary: 'First-person recollections documenting delta transformations across generations.',
+      preview:
+        'Transcripts reveal dialect variations and migratory patterns, with inline translator annotations.',
+      bookmarks: [64, 241, 322],
+      tts: true,
+      exportable: true
+    }
+  ]
+};
+
+const initialSettings = {
+  metadataSources: 'Douban, OpenLibrary',
+  apiKey: '',
+  rateLimit: 60,
+  proxy: '',
+  cachePath: '~/Library/Application Support/LocalBookshelf/covers',
+  previewPath: '~/Library/Application Support/LocalBookshelf/previews',
+  embeddingsPath: '~/Library/Application Support/LocalBookshelf/embeddings',
+  paginationDefault: 20,
+  theme: 'system',
+  analytics: true,
+  offline: false
+};
+
+const defaultWizardData = {
+  mode: 'create',
+  targetId: null,
+  paths: [],
+  name: '',
+  description: '',
+  coverName: '',
+  coverFile: null
+};
+
+module.exports = {
+  translations,
+  supportedCoverTypes,
+  classificationCatalog,
+  formatCatalog,
+  statEmojiMap,
+  collectionEmojiMap,
+  classificationEmojiMap,
+  enrichmentLabels,
+  classificationOptions,
+  formatOptions,
+  directoryOptions,
+  initialCollectionMetadata,
+  initialCollectionBooks,
+  initialSettings,
+  defaultWizardData
 };

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -1,364 +1,63 @@
-import { translations } from './data.js';
-
-const root = document.getElementById('root');
-
-const supportedCoverTypes = ['image/png', 'image/jpeg', 'image/webp'];
-
-const classificationCatalog = {
-  X4: { en: 'Environmental Science Fundamentals', zh: '环境科学基础理论' },
-  X5: { en: 'Environmental Protection Management', zh: '环境保护管理' },
-  F2: { en: 'National Economic Management', zh: '国民经济管理' },
-  F49: { en: 'Energy Economics', zh: '能源经济' },
-  TU201: { en: 'Urban Planning Theory', zh: '城市规划理论' },
-  TB472: { en: 'Industrial Design', zh: '工业设计' },
-  'TB472.1': { en: 'Design Systems', zh: '设计系统' },
-  I2067: { en: 'Modern Chinese Fiction', zh: '现代小说' },
-  I227: { en: 'Poetry', zh: '诗歌' },
-  I267: { en: 'Essays & Reportage', zh: '散文·报告文学' }
-};
-
-const formatCatalog = {
-  pdf: { en: 'PDF', zh: 'PDF' },
-  epub: { en: 'EPUB', zh: 'EPUB' },
-  mobi: { en: 'MOBI', zh: 'MOBI' },
-  docx: { en: 'DOCX', zh: 'DOCX' },
-  txt: { en: 'Plain Text', zh: '纯文本' },
-  azw3: { en: 'AZW3', zh: 'AZW3' }
-};
-
-const statEmojiMap = {
-  collections: '🗂️',
-  books: '📚',
-  enrichment: '✨',
-  reading: '🎧'
-};
-
-const collectionEmojiMap = {
-  'new-collection': '🌟',
-  climate: '🌤️',
-  design: '🎨',
-  literature: '📖'
-};
-
-const classificationEmojiMap = {
-  X4: '🌊',
-  X5: '🏙️',
-  F2: '🏛️',
-  F49: '🔋',
-  TU201: '🏗️',
-  TB472: '🎨',
-  'TB472.1': '🧩',
-  I2067: '📖',
-  I227: '🎴',
-  I267: '📝'
-};
-
-const enrichmentLabels = {
-  complete: { en: 'Complete', zh: '已完成' },
-  inprogress: { en: 'In Progress', zh: '进行中' },
-  queued: { en: 'Queued', zh: '排队中' },
-  failed: { en: 'Failed', zh: '失败' }
-};
-
-const classificationOptions = ['X4', 'X5', 'F2', 'F49', 'TU201', 'TB472', 'TB472.1', 'I2067', 'I227', 'I267'];
-
-const formatOptions = ['pdf', 'epub', 'mobi', 'docx', 'txt', 'azw3'];
-
-const directoryOptions = [
-  {
-    id: 'handbooks',
-    path: '/Volumes/Research/Climate-Handbooks',
-    helper: 'Shared folder mounted from NAS',
-    lastIndexed: '2024-05-22T08:30:00Z'
-  },
-  {
-    id: 'ipcc',
-    path: '/Users/alex/Documents/IPCC-AR6',
-    helper: 'Downloaded assessment reports',
-    lastIndexed: '2024-05-20T10:02:00Z'
-  },
-  {
-    id: 'design-system',
-    path: 'D:/Libraries/Design-Systems',
-    helper: 'Sketches, PDFs, and pattern audits',
-    lastIndexed: '2024-04-28T14:10:00Z'
-  },
-  {
-    id: 'literature',
-    path: '/Volumes/Archive/Modern-Literature',
-    helper: 'Digitised literary anthologies',
-    lastIndexed: '2024-05-12T21:40:00Z'
+let bootstrapData = {};
+if (window.api?.bootstrap) {
+  try {
+    bootstrapData = (await window.api.bootstrap()) || {};
+  } catch (error) {
+    console.error('Failed to load bootstrap data', error);
   }
-];
+} else {
+  console.warn('Bootstrap API is not available.');
+}
 
-const initialCollectionMetadata = {
-  climate: {
-    directories: ['/Volumes/Research/Climate-Handbooks', '/Users/alex/Documents/IPCC-AR6'],
-    lastScan: '2024-06-02T10:30:00Z',
-    pagination: 20,
-    aiEnabled: true
-  },
-  design: {
-    directories: ['D:/Libraries/Design-Systems', 'D:/Libraries/Accessibility-Guides'],
-    lastScan: '2024-05-28T18:20:00Z',
-    pagination: 12,
-    aiEnabled: true
-  },
-  literature: {
-    directories: ['/Volumes/Archive/Modern-Literature'],
-    lastScan: '2024-06-04T09:05:00Z',
-    pagination: 50,
-    aiEnabled: true
-  }
+const translations = bootstrapData.translations || {};
+
+const supportedCoverTypes = bootstrapData.supportedCoverTypes || ['image/png', 'image/jpeg', 'image/webp'];
+
+const classificationCatalog = bootstrapData.classificationCatalog || {};
+const formatCatalog = bootstrapData.formatCatalog || {};
+const statEmojiMap = bootstrapData.statEmojiMap || {};
+const collectionEmojiMap = bootstrapData.collectionEmojiMap || {};
+const classificationEmojiMap = bootstrapData.classificationEmojiMap || {};
+const enrichmentLabels = bootstrapData.enrichmentLabels || {};
+
+const classificationOptions =
+  Array.isArray(bootstrapData.classificationOptions) && bootstrapData.classificationOptions.length
+    ? bootstrapData.classificationOptions
+    : Object.keys(classificationCatalog);
+
+const formatOptions =
+  Array.isArray(bootstrapData.formatOptions) && bootstrapData.formatOptions.length
+    ? bootstrapData.formatOptions
+    : Object.keys(formatCatalog);
+
+const directoryOptions = Array.isArray(bootstrapData.directoryOptions) ? bootstrapData.directoryOptions : [];
+
+const initialCollectionMetadata = bootstrapData.initialCollectionMetadata || {};
+const initialCollectionBooks = bootstrapData.initialCollectionBooks || {};
+const defaultSettingsFallback = {
+  metadataSources: 'Douban, OpenLibrary',
+  apiKey: '',
+  rateLimit: 60,
+  proxy: '',
+  cachePath: '~/Library Application Support/LocalBookshelf/covers',
+  previewPath: '~/Library Application Support/LocalBookshelf/previews',
+  embeddingsPath: '~/Library Application Support/LocalBookshelf/embeddings',
+  paginationDefault: 20,
+  theme: 'system',
+  analytics: true,
+  offline: false
 };
+const initialSettings = { ...defaultSettingsFallback, ...(bootstrapData.initialSettings || {}) };
 
-const initialCollectionBooks = {
-  climate: [
-    {
-      id: 'climate-1',
-      title: 'Resilient Cities 2040',
-      author: 'Mara Liang',
-      classification: 'X5',
-      publicationYear: 2024,
-      format: 'pdf',
-      sizeMB: 18.4,
-      dateAdded: '2024-05-18',
-      enrichment: 'complete',
-      pages: 328,
-      progress: { currentPage: 215 },
-      isbn: '978-0-12-864302-1',
-      summary: 'Action playbook for municipal adaptation projects across coastal regions.',
-      preview:
-        'Chapter 7 synthesises community-led design sprints with parametric flood models, outlining a replicable strategy for mid-sized cities.',
-      bookmarks: [64, 214],
-      tts: true,
-      exportable: true
-    },
-    {
-      id: 'climate-2',
-      title: 'Policy Pathways for Net-Zero Provinces',
-      author: 'Dr. Felix Noor',
-      classification: 'F2',
-      publicationYear: 2022,
-      format: 'epub',
-      sizeMB: 6.2,
-      dateAdded: '2024-04-11',
-      enrichment: 'inprogress',
-      pages: 412,
-      progress: { currentPage: 87 },
-      isbn: '978-1-4028-9462-9',
-      summary: 'Comparative policy toolkit aligning provincial statutes with national carbon commitments.',
-      preview:
-        'Section 3.2 analyses differentiated responsibilities across heavy industry clusters with annotated case law.',
-      bookmarks: [23, 198],
-      tts: true,
-      exportable: true
-    },
-    {
-      id: 'climate-3',
-      title: 'Ocean Heat Budget Explorer',
-      author: 'IPCC Working Group I',
-      classification: 'X4',
-      publicationYear: 2023,
-      format: 'pdf',
-      sizeMB: 52.7,
-      dateAdded: '2024-03-07',
-      enrichment: 'complete',
-      pages: 512,
-      progress: { currentPage: 132 },
-      isbn: '978-0-321-87777-4',
-      summary: 'High-resolution datasets and visualisations for ocean heat content analysis.',
-      preview:
-        'Appendix D introduces a methodology for downscaling CMIP6 outputs with GPU-accelerated interpolation.',
-      bookmarks: [112, 256, 401],
-      tts: false,
-      exportable: true
-    },
-    {
-      id: 'climate-4',
-      title: 'Distributed Energy Retrofit Manual',
-      author: 'Helena Ortiz',
-      classification: 'F49',
-      publicationYear: 2021,
-      format: 'docx',
-      sizeMB: 9.1,
-      dateAdded: '2024-02-19',
-      enrichment: 'queued',
-      pages: 226,
-      progress: { currentPage: 34 },
-      isbn: '978-0-452-29078-6',
-      summary: 'Practical guidance for retrofitting mid-rise buildings with hybrid solar microgrids.',
-      preview:
-        'Workbook templates cover financial modelling, procurement sequencing, and occupant engagement scripts.',
-      bookmarks: [48],
-      tts: true,
-      exportable: true
-    }
-  ],
-  design: [
-    {
-      id: 'design-1',
-      title: 'Multi-Platform Design Tokens',
-      author: 'Lina Osei',
-      classification: 'TB472.1',
-      publicationYear: 2023,
-      format: 'pdf',
-      sizeMB: 12.2,
-      dateAdded: '2024-05-01',
-      enrichment: 'complete',
-      pages: 280,
-      progress: { currentPage: 144 },
-      isbn: '978-0-07-352343-1',
-      summary: 'Unified token taxonomy bridging web, desktop, and native mobile design systems.',
-      preview:
-        'The alignment matrix maps each decision token to platform accessibility requirements with traceable histories.',
-      bookmarks: [56, 233],
-      tts: true,
-      exportable: true
-    },
-    {
-      id: 'design-2',
-      title: 'Inclusive Motion Guidelines',
-      author: 'Yuko Nishimura',
-      classification: 'TB472',
-      publicationYear: 2020,
-      format: 'pdf',
-      sizeMB: 4.8,
-      dateAdded: '2024-04-16',
-      enrichment: 'complete',
-      pages: 164,
-      progress: { currentPage: 98 },
-      isbn: '978-0-12-549080-2',
-      summary: 'Framework for designing motion systems that respect vestibular comfort and localisation.',
-      preview:
-        'Case studies demonstrate velocity envelopes and offer CSS/SwiftUI code recipes to ship responsibly.',
-      bookmarks: [34, 88, 129],
-      tts: true,
-      exportable: true
-    },
-    {
-      id: 'design-3',
-      title: 'Operational Playbook for DesignOps',
-      author: 'Carlos Mendes',
-      classification: 'TB472',
-      publicationYear: 2021,
-      format: 'epub',
-      sizeMB: 5.6,
-      dateAdded: '2024-03-08',
-      enrichment: 'inprogress',
-      pages: 312,
-      progress: { currentPage: 201 },
-      isbn: '978-0-7637-2026-6',
-      summary: 'Roadmap for scaling design systems governance with measurable service levels.',
-      preview:
-        'The service blueprint highlights intake triage, triads, and backlog analytics for distributed teams.',
-      bookmarks: [76, 240],
-      tts: true,
-      exportable: true
-    },
-    {
-      id: 'design-4',
-      title: 'Accessibility Compliance Field Notes',
-      author: 'Priya Venkataraman',
-      classification: 'TB472',
-      publicationYear: 2019,
-      format: 'docx',
-      sizeMB: 3.4,
-      dateAdded: '2024-02-14',
-      enrichment: 'complete',
-      pages: 198,
-      progress: { currentPage: 45 },
-      isbn: '978-0-13-466535-4',
-      summary: 'Annotated checklist mapping WCAG 2.2 success criteria to practical inspection routines.',
-      preview:
-        'Field observations catalogue recurring defects and remediation scripts used by enterprise auditors.',
-      bookmarks: [18, 172],
-      tts: true,
-      exportable: true
-    }
-  ],
-  literature: [
-    {
-      id: 'literature-1',
-      title: 'Midnight Courtyard',
-      author: 'Han Yuerong',
-      classification: 'I2067',
-      publicationYear: 2018,
-      format: 'epub',
-      sizeMB: 2.3,
-      dateAdded: '2024-05-30',
-      enrichment: 'complete',
-      pages: 296,
-      progress: { currentPage: 186 },
-      isbn: '978-7-5321-6783-4',
-      summary: 'Interwoven narratives exploring urban solitude and resilience in Shanghai.',
-      preview:
-        'Chapter 12 juxtaposes architectural memories with present-day dialogues, inviting reflective annotation.',
-      bookmarks: [45, 132, 205],
-      tts: true,
-      exportable: true
-    },
-    {
-      id: 'literature-2',
-      title: 'Letters to the South Wind',
-      author: 'Qiu Ansheng',
-      classification: 'I267',
-      publicationYear: 2020,
-      format: 'pdf',
-      sizeMB: 7.9,
-      dateAdded: '2024-04-22',
-      enrichment: 'complete',
-      pages: 224,
-      progress: { currentPage: 44 },
-      isbn: '978-7-5366-9860-2',
-      summary: 'Literary reportage blending climate narratives with personal field diaries.',
-      preview:
-        'Essays weave metaphors from typhoon tracking data and oral histories collected along the coast.',
-      bookmarks: [38, 110],
-      tts: true,
-      exportable: true
-    },
-    {
-      id: 'literature-3',
-      title: 'Echoes on Lushan Trail',
-      author: 'Zhang Mingwei',
-      classification: 'I227',
-      publicationYear: 2015,
-      format: 'pdf',
-      sizeMB: 3.1,
-      dateAdded: '2024-03-19',
-      enrichment: 'inprogress',
-      pages: 168,
-      progress: { currentPage: 98 },
-      isbn: '978-7-5302-9342-7',
-      summary: 'Bilingual poetry sequence inspired by misty mornings in Jiangxi.',
-      preview:
-        'Bamboo stanza forms echo classical cadences while layering contemporary environmental imagery.',
-      bookmarks: [12, 97, 146],
-      tts: true,
-      exportable: true
-    },
-    {
-      id: 'literature-4',
-      title: 'Oral Histories of the Pearl Delta',
-      author: 'Luo Jia',
-      classification: 'I267',
-      publicationYear: 2017,
-      format: 'txt',
-      sizeMB: 1.1,
-      dateAdded: '2024-02-02',
-      enrichment: 'complete',
-      pages: 342,
-      progress: { currentPage: 276 },
-      isbn: '978-7-108-06618-2',
-      summary: 'First-person recollections documenting delta transformations across generations.',
-      preview:
-        'Transcripts reveal dialect variations and migratory patterns, with inline translator annotations.',
-      bookmarks: [64, 241, 322],
-      tts: true,
-      exportable: true
-    }
-  ]
+const defaultWizardTemplate = bootstrapData.defaultWizardData || {};
+const defaultWizardData = {
+  mode: defaultWizardTemplate.mode || 'create',
+  targetId: defaultWizardTemplate.targetId ?? null,
+  paths: Array.isArray(defaultWizardTemplate.paths) ? [...defaultWizardTemplate.paths] : [],
+  name: defaultWizardTemplate.name || '',
+  description: defaultWizardTemplate.description || '',
+  coverName: defaultWizardTemplate.coverName || '',
+  coverFile: null
 };
 
 const initialBookmarks = Object.values(initialCollectionBooks)
@@ -380,34 +79,13 @@ const initialPreviewStates = Object.values(initialCollectionBooks)
     return map;
   }, {});
 
-const initialSettings = {
-  metadataSources: 'Douban, OpenLibrary',
-  apiKey: '',
-  rateLimit: 60,
-  proxy: '',
-  cachePath: '~/Library/Application Support/LocalBookshelf/covers',
-  previewPath: '~/Library/Application Support/LocalBookshelf/previews',
-  embeddingsPath: '~/Library/Application Support/LocalBookshelf/embeddings',
-  paginationDefault: 20,
-  theme: 'system',
-  analytics: true,
-  offline: false
-};
+const availableLocales = Object.keys(translations);
+const defaultLocale = availableLocales.includes('en') ? 'en' : availableLocales[0] || 'en';
 
-let jobCounter = 0;
-
-const defaultWizardData = {
-  mode: 'create',
-  targetId: null,
-  paths: [],
-  name: '',
-  description: '',
-  coverName: '',
-  coverFile: null
-};
+const root = document.getElementById('root');
 
 const state = {
-  locale: 'en',
+  locale: defaultLocale,
   showWizard: false,
   wizardStep: 0,
   wizardData: { ...defaultWizardData },
@@ -673,7 +351,7 @@ function createElement(tag, options = {}) {
 }
 
 function getPack() {
-  return translations[state.locale];
+  return translations[state.locale] || translations.en || Object.values(translations)[0] || {};
 }
 
 function formatDate(dateString) {
@@ -2887,6 +2565,80 @@ function renderSettingsPage(pack) {
   readerGroup.appendChild(themeSelect);
   readerGroup.appendChild(analyticsToggle);
   readerGroup.appendChild(offlineToggle);
+
+  let systemGroup = null;
+  if (pack.settings.system) {
+    systemGroup = createElement('div', { className: 'settings-group system-group' });
+    systemGroup.appendChild(createElement('h3', { text: pack.settings.system.title }));
+    systemGroup.appendChild(createElement('p', { className: 'settings-helper', text: pack.settings.system.helper }));
+
+    const systemActions = createElement('div', { className: 'system-actions' });
+
+    const initializeButton = createElement('button', {
+      className: 'ghost-button danger',
+      text: `🧹 ${pack.settings.system.initialize}`
+    });
+    initializeButton.type = 'button';
+    initializeButton.addEventListener('click', async () => {
+      if (!window.confirm(pack.settings.system.initializeConfirm)) {
+        return;
+      }
+      if (!window.api?.initializeSystem) {
+        showToast(pack.settings.system.initializeFailure);
+        return;
+      }
+      initializeButton.disabled = true;
+      try {
+        const result = await window.api.initializeSystem();
+        if (result?.success) {
+          showToast(pack.settings.system.initializeSuccess);
+          setTimeout(() => {
+            window.location.reload();
+          }, 800);
+        } else {
+          showToast(pack.settings.system.initializeFailure);
+        }
+      } catch (error) {
+        console.error('Failed to initialize system', error);
+        showToast(pack.settings.system.initializeFailure);
+      } finally {
+        initializeButton.disabled = false;
+      }
+    });
+
+    const backupButton = createElement('button', {
+      className: 'ghost-button',
+      text: `💾 ${pack.settings.system.backup}`
+    });
+    backupButton.type = 'button';
+    backupButton.addEventListener('click', async () => {
+      if (!window.api?.backupSystem) {
+        showToast(pack.settings.system.backupFailure);
+        return;
+      }
+      backupButton.disabled = true;
+      try {
+        const result = await window.api.backupSystem();
+        if (result?.success && result.path) {
+          const message = (pack.settings.system.backupSuccess || '').replace('{path}', result.path);
+          showToast(message);
+        } else if (result?.cancelled) {
+          showToast(pack.settings.system.backupCanceled);
+        } else {
+          showToast(pack.settings.system.backupFailure);
+        }
+      } catch (error) {
+        console.error('Failed to back up system', error);
+        showToast(pack.settings.system.backupFailure);
+      } finally {
+        backupButton.disabled = false;
+      }
+    });
+
+    systemActions.appendChild(initializeButton);
+    systemActions.appendChild(backupButton);
+    systemGroup.appendChild(systemActions);
+  }
   const actions = createElement('div', { className: 'settings-actions' });
   const backButton = createElement('button', { className: 'ghost-button', text: pack.wizard.cancel });
   backButton.type = 'button';
@@ -2902,6 +2654,9 @@ function renderSettingsPage(pack) {
   panel.appendChild(metadataGroup);
   panel.appendChild(storageGroup);
   panel.appendChild(readerGroup);
+  if (systemGroup) {
+    panel.appendChild(systemGroup);
+  }
   panel.appendChild(actions);
   page.appendChild(panel);
   return page;

--- a/src/renderer/styles/global.css
+++ b/src/renderer/styles/global.css
@@ -364,6 +364,23 @@ body {
   border-color: #1e3a8a;
 }
 
+.ghost-button.danger {
+  background: #fee2e2;
+  border-color: #fca5a5;
+  color: #b91c1c;
+}
+
+.ghost-button.danger:hover {
+  background: #dc2626;
+  border-color: #b91c1c;
+  color: #ffffff;
+}
+
+.ghost-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .collection-hero {
   display: flex;
   justify-content: space-between;
@@ -1164,6 +1181,19 @@ body {
 .settings-group label {
   font-size: 0.9rem;
   color: #475569;
+}
+
+.settings-helper {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.system-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 8px;
 }
 
 .settings-actions {


### PR DESCRIPTION
## Summary
- store demo content and persisted state in a local SQLite database with seed data
- bootstrap the renderer from IPC, expose new preload helpers, and drop the old bundled data module
- add system maintenance controls for initialization and backups plus supporting styles in the settings view

## Testing
- npm install *(fails: 403 Forbidden when fetching better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_68e642b7de708320be113c4eace12e35