### PR TITLE
Fix better-sqlite3 build failure on Node 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "electron": "^28.2.0"
       },
       "dependencies": {
-        "better-sqlite3": "^8.5.2"
+        "better-sqlite3": "^9.4.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "electron": "^28.2.0"
   },
   "dependencies": {
-    "better-sqlite3": "^8.5.2"
+    "better-sqlite3": "^9.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump better-sqlite3 to ^9.4.0 so native build works with Node.js 22

## Testing
- npm install *(fails in sandbox: registry.npmjs.org returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e6748b15c083208da51786b7bdf9db